### PR TITLE
Fix all songs causing crash with 'UnrecognisedFormat', and subset of songs causing crash with 'End of stream' (Resolves #113, #95)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,34 @@
+name: CD # Continuous Deployment
+
+permissions:
+  contents: read
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: startsWith(github.event.release.name, 'youtui-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install linux deps
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends git libasound2-dev pkg-config makepkg
+      - name: Echo package name
+        run: |
+          echo ${{ github.event.release.name }}
+      - name: Clone aur
+        run: |
+          git clone https://aur.archlinux.org/youtui.git
+          cd youtui && ls 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,20 +2690,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rodio"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
-dependencies = [
- "claxon",
- "cpal",
- "hound",
- "lewton",
- "symphonia",
- "thiserror",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,7 +4268,6 @@ dependencies = [
  "gag",
  "itertools 0.13.0",
  "ratatui",
- "rodio",
  "serde",
  "serde_json",
  "tokio",
@@ -4290,8 +4275,23 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-logger",
+ "youtui-vendored-rodio",
  "youtui-vendored-rusty_ytdl",
  "ytmapi-rs",
+]
+
+[[package]]
+name = "youtui-vendored-rodio"
+version = "0.19.0-youtui-vendored.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04dcacfe72ecd1a41ac89e008ab863febd3fcb778d4d7037c96871b86d6a3ef"
+dependencies = [
+ "claxon",
+ "cpal",
+ "hound",
+ "lewton",
+ "symphonia",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ dependencies = [
  "crossterm_winapi",
  "futures-core",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot 0.12.3",
  "signal-hook",
  "signal-hook-mio",
@@ -1831,6 +1831,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,16 +1958,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2783,38 +2785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
-name = "rusty_ytdl"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09282236fefb68cac2edaaf66fa899c0c18fcdb2e3d5aea8379863efa9f00877"
-dependencies = [
- "aes",
- "async-trait",
- "boa_engine",
- "bytes",
- "cbc",
- "derivative",
- "derive_more",
- "hex",
- "m3u8-rs",
- "mime",
- "once_cell",
- "rand",
- "regex",
- "reqwest",
- "reqwest-middleware",
- "reqwest-retry",
- "scraper",
- "serde",
- "serde_json",
- "serde_qs",
- "thiserror",
- "tokio",
- "url",
- "urlencoding",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3029,7 +2999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -3477,28 +3447,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.1",
  "parking_lot 0.12.3",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4314,7 +4283,6 @@ dependencies = [
  "itertools 0.13.0",
  "ratatui",
  "rodio",
- "rusty_ytdl",
  "serde",
  "serde_json",
  "tokio",
@@ -4322,7 +4290,40 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-logger",
+ "youtui-vendored-rusty_ytdl",
  "ytmapi-rs",
+]
+
+[[package]]
+name = "youtui-vendored-rusty_ytdl"
+version = "0.7.3-youtui-vendored.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a84940e62ac6704051644261eb63c5542a8e6711bdb4723099199bbb35930a"
+dependencies = [
+ "aes",
+ "async-trait",
+ "boa_engine",
+ "bytes",
+ "cbc",
+ "derivative",
+ "derive_more",
+ "hex",
+ "m3u8-rs",
+ "mime",
+ "once_cell",
+ "rand",
+ "regex",
+ "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
+ "scraper",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "thiserror",
+ "tokio",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/youtui/Cargo.toml
+++ b/youtui/Cargo.toml
@@ -31,10 +31,12 @@ tui-logger = { version = "0.11.2", default-features = false, features = [
   "crossterm",
   "tracing-support",
 ] }
-rusty_ytdl = { version = "0.7.3", default-features = false, features = [
+rusty_ytdl = { default-features = false, features = [
   "live",
   "rustls-tls",
-] }
+], version = "0.7.3-youtui-vendored.1", package = "youtui-vendored-rusty_ytdl" }
+# Accommodate for vendoring if required - a change to YouTube API may break downloading.
+# ], version = "0.7.3" }
 rodio = { version = "0.19.0", features = ["symphonia-all"] }
 directories = "5.0.1"
 gag = "1.0.0"

--- a/youtui/Cargo.toml
+++ b/youtui/Cargo.toml
@@ -31,16 +31,26 @@ tui-logger = { version = "0.11.2", default-features = false, features = [
   "crossterm",
   "tracing-support",
 ] }
-rusty_ytdl = { default-features = false, features = [
-  "live",
-  "rustls-tls",
-], version = "0.7.3-youtui-vendored.1", package = "youtui-vendored-rusty_ytdl" }
-# Accommodate for vendoring if required - a change to YouTube API may break downloading.
-# ], version = "0.7.3" }
-rodio = { version = "0.19.0", features = ["symphonia-all"] }
 directories = "5.0.1"
 gag = "1.0.0"
 toml = "0.8.14"
 # For intersperse feature. RFC in progress to bring to std
 # https://github.com/rust-lang/rust/issues/79524
 itertools = "0.13.0"
+
+# Accommodate for vendoring if required - a change to YouTube API may break downloading or playback.
+[dependencies.rodio]
+# version = "0.19.0"
+version = "0.19.0-youtui-vendored.1"
+package = "youtui-vendored-rodio"
+features = ["symphonia-all"]
+
+[dependencies.rusty_ytdl]
+# version = "0.7.3"
+version = "0.7.3-youtui-vendored.1"
+package = "youtui-vendored-rusty_ytdl"
+default-features = false
+features = [
+  "live",
+  "rustls-tls",
+]

--- a/youtui/src/app/taskmanager.rs
+++ b/youtui/src/app/taskmanager.rs
@@ -414,6 +414,12 @@ impl TaskManager {
                 }
                 ui_state.handle_set_to_stopped(song_id).await;
             }
+            player::Response::Error(song_id, id) => {
+                if !self.is_task_valid(id) {
+                    return;
+                }
+                ui_state.handle_set_to_error(song_id).await;
+            }
             player::Response::ProgressUpdate(perc, song_id, id) => {
                 if !self.is_task_valid(id) {
                     return;

--- a/youtui/src/app/ui.rs
+++ b/youtui/src/app/ui.rs
@@ -341,6 +341,9 @@ impl YoutuiWindow {
     pub async fn handle_set_to_stopped(&mut self, id: ListSongID) {
         self.playlist.handle_set_to_stopped(id)
     }
+    pub async fn handle_set_to_error(&mut self, id: ListSongID) {
+        self.playlist.handle_set_to_error(id)
+    }
     pub fn handle_set_volume(&mut self, p: Percentage) {
         self.playlist.handle_set_volume(p)
     }

--- a/youtui/src/app/ui/footer.rs
+++ b/youtui/src/app/ui/footer.rs
@@ -53,7 +53,10 @@ pub fn draw_footer(f: &mut Frame, w: &super::YoutuiWindow, chunk: Rect) {
     let duration_str = secs_to_time_string(duration);
     let bar_str = format!("{}/{}", progress_str, duration_str);
     let song_title = match w.playlist.play_status {
-        PlayState::Playing(id) | PlayState::Paused(id) | PlayState::Buffering(id) => w
+        PlayState::Error(id)
+        | PlayState::Playing(id)
+        | PlayState::Paused(id)
+        | PlayState::Buffering(id) => w
             .playlist
             .get_song_from_id(id)
             .map(|s| s.raw.title.to_owned())
@@ -62,7 +65,10 @@ pub fn draw_footer(f: &mut Frame, w: &super::YoutuiWindow, chunk: Rect) {
         PlayState::Stopped => "Not playing".to_string(),
     };
     let album_title = match w.playlist.play_status {
-        PlayState::Playing(id) | PlayState::Paused(id) | PlayState::Buffering(id) => w
+        PlayState::Error(id)
+        | PlayState::Playing(id)
+        | PlayState::Paused(id)
+        | PlayState::Buffering(id) => w
             .playlist
             .get_song_from_id(id)
             .map(|s| s.get_album().to_owned())
@@ -71,7 +77,10 @@ pub fn draw_footer(f: &mut Frame, w: &super::YoutuiWindow, chunk: Rect) {
         PlayState::Stopped => "".to_string(),
     };
     let artist_title = match w.playlist.play_status {
-        PlayState::Playing(id) | PlayState::Paused(id) | PlayState::Buffering(id) => w
+        PlayState::Error(id)
+        | PlayState::Playing(id)
+        | PlayState::Paused(id)
+        | PlayState::Buffering(id) => w
             .playlist
             .get_song_from_id(id)
             // TODO: tidy this up as ListSong only contains one artist currently.
@@ -88,7 +97,10 @@ pub fn draw_footer(f: &mut Frame, w: &super::YoutuiWindow, chunk: Rect) {
         PlayState::Stopped => "".to_string(),
     };
     let song_title_string = match w.playlist.play_status {
-        PlayState::Playing(_) | PlayState::Paused(_) | PlayState::Buffering(_) => format!(
+        PlayState::Error(_)
+        | PlayState::Playing(_)
+        | PlayState::Paused(_)
+        | PlayState::Buffering(_) => format!(
             "{} {song_title} - {artist_title}",
             w.playlist.play_status.list_icon()
         ),


### PR DESCRIPTION
Downloads will now retry up to five times, and playback errors will no longer crash applications.