### PR TITLE
fix!: error if unknown fields in config file

### DIFF
--- a/youtui/src/config.rs
+++ b/youtui/src/config.rs
@@ -74,7 +74,7 @@ impl Default for Config {
 }
 
 #[derive(Default, Debug, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 /// Intermediate representation of Config for serde.
 pub struct ConfigIR {
     pub auth_type: AuthType,

--- a/youtui/src/config.rs
+++ b/youtui/src/config.rs
@@ -157,8 +157,13 @@ mod tests {
     }
     #[tokio::test]
     async fn test_unknown_keys_in_config() {
-        let config_file = r#"auth_typo = "Browser"#;
-        let ir: Result<ConfigIR, _> = toml::from_str(config_file);
+        let config_file = r#"auth_typo = 'Browser'"#;
+        // ASSERT: the provided toml is valid so therefore the error is related
+        // specifically to parsing into [ConfigIR]
+        //
+        // See https://github.com/nick42d/youtui/pull/366
+        let config_toml: toml::Value = toml::from_str(config_file).unwrap();
+        let ir: Result<ConfigIR, _> = config_toml.try_into();
         assert!(ir.is_err());
     }
     #[tokio::test]

--- a/youtui/src/config.rs
+++ b/youtui/src/config.rs
@@ -170,7 +170,12 @@ mod tests {
     async fn test_unknown_keybind_parameters() {
         let config_file = r#"[keybinds.global]
 raisevolume = {action = "vol_up", visiblity = "hidden"}"#;
-        let ir: Result<ConfigIR, _> = toml::from_str(config_file);
+        // ASSERT: the provided toml is valid so therefore the error is related
+        // specifically to parsing into [ConfigIR]
+        //
+        // See https://github.com/nick42d/youtui/pull/366
+        let config_toml: toml::Value = toml::from_str(config_file).unwrap();
+        let ir: Result<ConfigIR, _> = config_toml.try_into();
         assert!(ir.is_err());
     }
     #[tokio::test]


### PR DESCRIPTION
In #360, a user had an AI generated config file containing hallucinated fields. This should be rejected instead of blindly accepted as otherwise a user may mistakenly report issues with features that dont exist or have been configured incorrectly.