### PR TITLE
fix: Handle search results wrapped in `itemSectionRenderer` - v2

### DIFF
--- a/json-crawler/src/lib.rs
+++ b/json-crawler/src/lib.rs
@@ -199,6 +199,23 @@ pub struct JsonCrawlerBorrowed<'a> {
     path: PathList,
 }
 
+impl<'a> JsonCrawlerBorrowed<'a> {
+    /// Take the contents of the currently crawled location as an owned crawler,
+    /// leaving a null in its place.
+    pub fn take_crawler(self) -> JsonCrawlerOwned {
+        let Self {
+            source,
+            crawler,
+            path,
+        } = self;
+        JsonCrawlerOwned {
+            source,
+            crawler: crawler.take(),
+            path,
+        }
+    }
+}
+
 impl JsonCrawlerOwned {
     /// Create a new JsonCrawler, where 'json' is the `serde_json::Value` that
     /// you wish to crawl and 'source' represents a serialized copy of the same

--- a/youtui/src/app/server/api.rs
+++ b/youtui/src/app/server/api.rs
@@ -160,25 +160,27 @@ where
 
 async fn search_playlists(api: ConcurrentApi, text: String) -> Result<Vec<SearchResultPlaylist>> {
     tracing::info!("Searching playlists for {text}");
-    let query = ytmapi_rs::query::SearchQuery::new(text)
-        .with_filter(ytmapi_rs::query::search::PlaylistsFilter)
-        .with_spelling_mode(ytmapi_rs::query::search::SpellingMode::ExactMatch);
+    let query = ytmapi_rs::query::SearchQuery::new_filtered(
+        text,
+        ytmapi_rs::query::search::PlaylistsFilter,
+    )
+    .with_spelling_mode(ytmapi_rs::query::search::SpellingMode::ExactMatch);
     query_api_with_retry(&api, query).await
 }
 
 async fn search_artists(api: ConcurrentApi, text: String) -> Result<Vec<SearchResultArtist>> {
     tracing::info!("Searching artists for {text}");
-    let query = ytmapi_rs::query::SearchQuery::new(text)
-        .with_filter(ytmapi_rs::query::search::ArtistsFilter)
-        .with_spelling_mode(ytmapi_rs::query::search::SpellingMode::ExactMatch);
+    let query =
+        ytmapi_rs::query::SearchQuery::new_filtered(text, ytmapi_rs::query::search::ArtistsFilter)
+            .with_spelling_mode(ytmapi_rs::query::search::SpellingMode::ExactMatch);
     query_api_with_retry(&api, query).await
 }
 
 async fn search_songs(api: ConcurrentApi, text: String) -> Result<Vec<SearchResultSong>> {
     tracing::info!("Searching songs for {text}");
-    let query = ytmapi_rs::query::SearchQuery::new(text)
-        .with_filter(ytmapi_rs::query::search::SongsFilter)
-        .with_spelling_mode(ytmapi_rs::query::search::SpellingMode::ExactMatch);
+    let query =
+        ytmapi_rs::query::SearchQuery::new_filtered(text, ytmapi_rs::query::search::SongsFilter)
+            .with_spelling_mode(ytmapi_rs::query::search::SpellingMode::ExactMatch);
     query_api_with_retry(&api, query).await
 }
 

--- a/youtui/src/cli/querybuilder.rs
+++ b/youtui/src/cli/querybuilder.rs
@@ -121,7 +121,7 @@ pub async fn command_to_query(
         Command::SearchArtists { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(ArtistsFilter),
+                SearchQuery::new_filtered(query, ArtistsFilter),
                 cli_query,
                 max_pages,
             )
@@ -130,7 +130,7 @@ pub async fn command_to_query(
         Command::SearchAlbums { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(AlbumsFilter),
+                SearchQuery::new_filtered(query, AlbumsFilter),
                 cli_query,
                 max_pages,
             )
@@ -139,7 +139,7 @@ pub async fn command_to_query(
         Command::SearchSongs { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(SongsFilter),
+                SearchQuery::new_filtered(query, SongsFilter),
                 cli_query,
                 max_pages,
             )
@@ -148,7 +148,7 @@ pub async fn command_to_query(
         Command::SearchPlaylists { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(PlaylistsFilter),
+                SearchQuery::new_filtered(query, PlaylistsFilter),
                 cli_query,
                 max_pages,
             )
@@ -157,7 +157,7 @@ pub async fn command_to_query(
         Command::SearchCommunityPlaylists { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(CommunityPlaylistsFilter),
+                SearchQuery::new_filtered(query, CommunityPlaylistsFilter),
                 cli_query,
                 max_pages,
             )
@@ -166,7 +166,7 @@ pub async fn command_to_query(
         Command::SearchFeaturedPlaylists { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(FeaturedPlaylistsFilter),
+                SearchQuery::new_filtered(query, FeaturedPlaylistsFilter),
                 cli_query,
                 max_pages,
             )
@@ -175,7 +175,7 @@ pub async fn command_to_query(
         Command::SearchVideos { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(VideosFilter),
+                SearchQuery::new_filtered(query, VideosFilter),
                 cli_query,
                 max_pages,
             )
@@ -184,7 +184,7 @@ pub async fn command_to_query(
         Command::SearchEpisodes { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(EpisodesFilter),
+                SearchQuery::new_filtered(query, EpisodesFilter),
                 cli_query,
                 max_pages,
             )
@@ -193,7 +193,7 @@ pub async fn command_to_query(
         Command::SearchProfiles { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(ProfilesFilter),
+                SearchQuery::new_filtered(query, ProfilesFilter),
                 cli_query,
                 max_pages,
             )
@@ -202,7 +202,7 @@ pub async fn command_to_query(
         Command::SearchPodcasts { query, max_pages } => {
             get_string_output_of_streaming_query(
                 yt,
-                SearchQuery::new(query).with_filter(PodcastsFilter),
+                SearchQuery::new_filtered(query, PodcastsFilter),
                 cli_query,
                 max_pages,
             )

--- a/ytmapi-rs/src/parse/search.rs
+++ b/ytmapi-rs/src/parse/search.rs
@@ -22,8 +22,10 @@ use crate::query::*;
 use crate::youtube_enums::{PlaylistEndpointParams, YoutubeMusicPageType};
 use crate::{Error, Result};
 use const_format::concatcp;
-use itertools::Itertools;
-use json_crawler::{JsonCrawler, JsonCrawlerBorrowed, JsonCrawlerIterator, JsonCrawlerOwned};
+use itertools::{Either, Itertools};
+use json_crawler::{
+    CrawlerResult, JsonCrawler, JsonCrawlerBorrowed, JsonCrawlerIterator, JsonCrawlerOwned,
+};
 use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 
@@ -845,6 +847,7 @@ fn parse_playlist_search_result_from_music_shelf_contents(
 
 struct FilteredSearchSectionContents(JsonCrawlerOwned);
 struct FilteredSearchMusicShelfContents(JsonCrawlerOwned);
+struct MusicResponsiveListItemRenderer(JsonCrawlerOwned);
 struct BasicSearchSectionListContents(JsonCrawlerOwned);
 // In this case, we've searched and had no results found.
 // We are being quite explicit here to avoid a false positive.
@@ -923,6 +926,40 @@ impl<'a, F: FilteredSearchType> TryFrom<ProcessedResult<'a, SearchQuery<'a, Filt
         ))?;
         Ok(FilteredSearchSectionContents(section_contents))
     }
+}
+fn get_mrlir_at_location(
+    location: JsonCrawlerOwned,
+) -> json_crawler::CrawlerResult<MusicResponsiveListItemRenderer> {
+    location
+        .navigate_pointer(MRLIR)
+        .map(MusicResponsiveListItemRenderer)
+}
+fn get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+    mut section_contents: FilteredSearchSectionContents,
+) -> Result<impl Iterator<Item = json_crawler::CrawlerResult<MusicResponsiveListItemRenderer>>> {
+    let parsers: [fn(&mut JsonCrawlerOwned) -> _; 2] = [
+        |contents| {
+            let iter = contents
+                .try_iter_mut()?
+                .find_path(concatcp!(MUSIC_SHELF, "/contents"))?
+                .take_crawler()
+                .try_into_iter()?
+                .map(get_mrlir_at_location);
+            Ok(Either::left(iter))
+        },
+        |contents| {
+            let iter = contents
+                .try_iter_mut()?
+                .map(|content| content.navigate_pointer("/itemSectionRenderer/contents/0"))
+                .map(|maybe_content| maybe_content.map(JsonCrawlerBorrowed::take_crawler))
+                .map(|maybe_content| maybe_content.map(get_mrlir_at_location));
+            Ok(Either::Right(iter))
+        },
+    ];
+    section_contents
+        .0
+        .try_functions(parsers)
+        .map_err(Into::into)
 }
 impl TryFrom<FilteredSearchSectionContents> for FilteredSearchMusicShelfContents {
     type Error = Error;

--- a/ytmapi-rs/src/parse/search.rs
+++ b/ytmapi-rs/src/parse/search.rs
@@ -296,7 +296,9 @@ fn parse_basic_search_result_from_section_list_contents(
                 community_playlists = category
                     .navigate_pointer("/contents")?
                     .try_into_iter()?
-                    .map(|r| parse_community_playlist_basic_search_result_from_mrlir(r))
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_community_playlist_basic_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<BasicSearchResultCommunityPlaylist>>>()?
             }
             SearchResultType::Songs => {
@@ -312,7 +314,9 @@ fn parse_basic_search_result_from_section_list_contents(
                 videos = category
                     .navigate_pointer("/contents")?
                     .try_into_iter()?
-                    .filter_map(|r| parse_video_search_result_from_mrlir(r).transpose())
+                    .map(get_mrlir_at_location)
+                    .filter_map_ok(|r| parse_video_search_result_from_mrlir(r).transpose())
+                    .flatten()
                     .collect::<Result<Vec<SearchResultVideo>>>()?
             }
             SearchResultType::Podcasts => {
@@ -777,8 +781,9 @@ fn parse_featured_playlist_search_result_from_mrlir(
 fn parse_community_playlist_basic_search_result_from_mrlir(
     mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<BasicSearchResultCommunityPlaylist> {
-    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
-    let result_type = mrlir.borrow_value_pointer(concatcp!(NAVIGATION_BROWSE, PAGE_TYPE))?;
+    let result_type = mrlir
+        .0
+        .borrow_value_pointer(concatcp!(NAVIGATION_BROWSE, PAGE_TYPE))?;
     let result = match result_type {
         YoutubeMusicPageType::Podcast => BasicSearchResultCommunityPlaylist::Podcast(
             parse_podcast_search_result_from_mrlir(mrlir)?,
@@ -808,11 +813,11 @@ fn parse_community_playlist_search_result_from_mrlir(
 }
 
 fn parse_playlist_search_result_from_mrlir(
-    mrlir: MusicResponsiveListItemRenderer,
+    mut mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultPlaylist> {
-    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
-    let result_type: YoutubeMusicPageType =
-        mrlir.borrow_value_pointer(concatcp!(NAVIGATION_BROWSE, PAGE_TYPE))?;
+    let result_type: YoutubeMusicPageType = mrlir
+        .0
+        .borrow_value_pointer(concatcp!(NAVIGATION_BROWSE, PAGE_TYPE))?;
 
     // Search result for this query can be Podcast or Playlist.
     match result_type {
@@ -822,7 +827,7 @@ fn parse_playlist_search_result_from_mrlir(
         }
         YoutubeMusicPageType::Playlist => {
             // The playlist search contains a mix of Community and Featured playlists.
-            let playlist_params: PlaylistEndpointParams = mrlir.take_value_pointer(concatcp!(
+            let playlist_params: PlaylistEndpointParams = mrlir.0.take_value_pointer(concatcp!(
                 PLAY_BUTTON,
                 "/playNavigationEndpoint/watchPlaylistEndpoint/params"
             ))?;
@@ -867,19 +872,53 @@ fn take_continuation_params_from_section_contents(
         .transpose()
         .map_err(Into::into)
 }
-fn get_filtered_search_continuation_music_shelf_contents_and_params(
+fn get_mrlir_at_location(location: JsonCrawlerOwned) -> Result<MusicResponsiveListItemRenderer> {
+    location
+        .navigate_pointer(MRLIR)
+        .map_err(Into::into)
+        .map(MusicResponsiveListItemRenderer)
+}
+fn get_filtered_search_continuation_mrlirs_and_params(
     crawler: JsonCrawlerOwned,
 ) -> Result<(
-    FilteredSearchMusicShelfContents,
+    impl Iterator<Item = Result<MusicResponsiveListItemRenderer>>,
     Option<ContinuationParams<'static>>,
 )> {
     let mut music_shelf = crawler.navigate_pointer(MUSIC_SHELF_CONTINUATION)?;
     let continuation_params = music_shelf.take_value_pointer(CONTINUATION_PARAMS).ok();
-    let contents = music_shelf.navigate_pointer("/contents")?;
-    Ok((
-        FilteredSearchMusicShelfContents(contents),
-        continuation_params,
-    ))
+    let mrlirs = music_shelf
+        .navigate_pointer("/contents")?
+        .try_into_iter()?
+        .map(get_mrlir_at_location);
+    Ok((mrlirs, continuation_params))
+}
+fn get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+    mut section_contents: FilteredSearchSectionContents,
+) -> Result<impl Iterator<Item = Result<MusicResponsiveListItemRenderer>>> {
+    let parsers: [fn(&mut JsonCrawlerOwned) -> _; 2] = [
+        |contents| {
+            let iter = contents
+                .try_iter_mut()?
+                .find_path(concatcp!(MUSIC_SHELF, "/contents"))?
+                .take_crawler()
+                .try_into_iter()?
+                .map(get_mrlir_at_location);
+            Ok(Either::Left(iter))
+        },
+        |contents| {
+            let iter = contents
+                .borrow_mut()
+                .take_crawler()
+                .try_into_iter()?
+                .map(|content| Ok(content.navigate_pointer("/itemSectionRenderer/contents/0")?))
+                .map(|maybe_content| maybe_content.and_then(get_mrlir_at_location));
+            Ok(Either::Right(iter))
+        },
+    ];
+    section_contents
+        .0
+        .try_functions(parsers)
+        .map_err(Into::into)
 }
 // TODO: Consolidate these two functions into single function.
 // TODO: This could be implemented with a non-mutable array also.
@@ -922,170 +961,6 @@ impl<'a, F: FilteredSearchType> TryFrom<ProcessedResult<'a, SearchQuery<'a, Filt
         Ok(FilteredSearchSectionContents(section_contents))
     }
 }
-fn get_mrlir_at_location(location: JsonCrawlerOwned) -> Result<MusicResponsiveListItemRenderer> {
-    location
-        .navigate_pointer(MRLIR)
-        .map_err(Into::into)
-        .map(MusicResponsiveListItemRenderer)
-}
-fn get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
-    mut section_contents: FilteredSearchSectionContents,
-) -> Result<impl Iterator<Item = Result<MusicResponsiveListItemRenderer>>> {
-    let parsers: [fn(&mut JsonCrawlerOwned) -> _; 2] = [
-        |contents| {
-            let iter = contents
-                .try_iter_mut()?
-                .find_path(concatcp!(MUSIC_SHELF, "/contents"))?
-                .take_crawler()
-                .try_into_iter()?
-                .map(get_mrlir_at_location);
-            Ok(Either::Left(iter))
-        },
-        |contents| {
-            let iter = contents
-                .borrow_mut()
-                .take_crawler()
-                .try_into_iter()?
-                .map(|content| Ok(content.navigate_pointer("/itemSectionRenderer/contents/0")?))
-                .map(|maybe_content| maybe_content.and_then(get_mrlir_at_location));
-            Ok(Either::Right(iter))
-        },
-    ];
-    section_contents
-        .0
-        .try_functions(parsers)
-        .map_err(Into::into)
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultAlbum> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_album_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultProfile> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_profile_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultArtist> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_artist_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultSong> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_song_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultVideo> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .filter_map(|a| parse_video_search_result_from_mrlir(a).transpose())
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultEpisode> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_episode_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultPodcast> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_podcast_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultPlaylist> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_playlist_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultCommunityPlaylist> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_community_playlist_search_result_from_mrlir(a))
-            .collect()
-    }
-}
-impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultFeaturedPlaylist> {
-    type Error = Error;
-    fn try_from(
-        mut value: FilteredSearchMusicShelfContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        // TODO: Make this a From method.
-        value
-            .0
-            .try_iter_mut()?
-            .map(|a| parse_featured_playlist_search_result_from_mrlir(a))
-            .collect()
-    }
-}
 impl<'a, S: UnfilteredSearchType> ParseFrom<SearchQuery<'a, S>> for SearchResults {
     fn parse_from(p: ProcessedResult<SearchQuery<'a, S>>) -> crate::Result<Self> {
         let mut section_list_contents = BasicSearchSectionListContents::try_from(p)?;
@@ -1108,7 +983,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<ArtistsFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_artist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1118,8 +999,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<ArtistsFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_artist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1139,8 +1023,9 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<ProfilesFilter>>>
             get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
                 section_contents,
             )?
-            .map(|maybe_mrlir| maybe_mrlir.and_then(parse_profile_search_result_from_mrlir))
-            .collect()?;
+            .map_ok(parse_profile_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1150,8 +1035,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<ProfilesFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_profile_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1167,7 +1055,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<AlbumsFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_album_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1177,8 +1071,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<AlbumsFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_album_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1194,7 +1091,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<SongsFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_song_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1202,8 +1105,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<SongsFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_song_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1219,7 +1125,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<VideosFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .filter_map_ok(|mrlir| parse_video_search_result_from_mrlir(mrlir).transpose())
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1229,8 +1141,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<VideosFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .filter_map_ok(|mrlir| parse_video_search_result_from_mrlir(mrlir).transpose())
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1246,7 +1161,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<EpisodesFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_episode_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1256,8 +1177,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<EpisodesFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_episode_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1273,7 +1197,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<PodcastsFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_podcast_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1283,8 +1213,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<PodcastsFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_podcast_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1300,7 +1233,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<CommunityPlaylistsF
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_playlist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1310,8 +1249,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<CommunityPlaylistsF
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_playlist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1327,7 +1269,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<FeaturedPlaylistsFi
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_featured_playlist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1337,8 +1285,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<FeaturedPlaylistsFi
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_featured_playlist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }
@@ -1354,7 +1305,13 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<PlaylistsFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map_ok(parse_playlist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(
@@ -1364,8 +1321,11 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<PlaylistsFilter>>>
     ) -> crate::Result<(Self, Option<crate::common::ContinuationParams<'static>>)> {
         let crawler: JsonCrawlerOwned = p.into();
         let (contents, continuation_params) =
-            get_filtered_search_continuation_music_shelf_contents_and_params(crawler)?;
-        let results = contents.try_into()?;
+            get_filtered_search_continuation_mrlirs_and_params(crawler)?;
+        let results = contents
+            .map_ok(parse_playlist_search_result_from_mrlir)
+            .flatten()
+            .collect::<Result<_>>()?;
         Ok((results, continuation_params))
     }
 }

--- a/ytmapi-rs/src/parse/search.rs
+++ b/ytmapi-rs/src/parse/search.rs
@@ -268,68 +268,78 @@ fn parse_basic_search_result_from_section_list_contents(
             SearchResultType::Artists => {
                 artists = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_artist_search_result_from_music_shelf_contents(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_artist_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultArtist>>>()?;
             }
             SearchResultType::Albums => {
                 albums = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_album_search_result_from_music_shelf_contents(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_album_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultAlbum>>>()?
             }
             SearchResultType::FeaturedPlaylists => {
                 featured_playlists = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_featured_playlist_search_result_from_music_shelf_contents(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_featured_playlist_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultFeaturedPlaylist>>>()?
             }
             SearchResultType::CommunityPlaylists => {
                 community_playlists = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| {
-                        parse_community_playlist_basic_search_result_from_music_shelf_contents(r)
-                    })
+                    .try_into_iter()?
+                    .map(|r| parse_community_playlist_basic_search_result_from_mrlir(r))
                     .collect::<Result<Vec<BasicSearchResultCommunityPlaylist>>>()?
             }
             SearchResultType::Songs => {
                 songs = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_song_search_result_from_music_shelf_contents(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_song_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultSong>>>()?
             }
             SearchResultType::Videos => {
                 videos = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .filter_map(|r| {
-                        parse_video_search_result_from_music_shelf_contents(r).transpose()
-                    })
+                    .try_into_iter()?
+                    .filter_map(|r| parse_video_search_result_from_mrlir(r).transpose())
                     .collect::<Result<Vec<SearchResultVideo>>>()?
             }
             SearchResultType::Podcasts => {
                 podcasts = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_podcast_search_result_from_music_shelf_contents(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_podcast_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultPodcast>>>()?
             }
             SearchResultType::Episodes => {
                 episodes = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_episode_search_result_from_music_shelf_contents(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_episode_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultEpisode>>>()?
             }
             SearchResultType::Profiles => {
                 profiles = category
                     .navigate_pointer("/contents")?
-                    .try_iter_mut()?
-                    .map(|r| parse_profile_search_result_from_mrlir(r))
+                    .try_into_iter()?
+                    .map(get_mrlir_at_location)
+                    .map_ok(parse_profile_search_result_from_mrlir)
+                    .flatten()
                     .collect::<Result<Vec<SearchResultProfile>>>()?
             }
         }
@@ -481,12 +491,11 @@ fn parse_top_result_from_music_shelf_contents(
         byline: None,
     }))
 }
-// TODO: Type safety
 // TODO: Tests
-fn parse_artist_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_artist_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultArtist> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let artist = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let subscribers = parse_flex_column_item(&mut mrlir, 1, 2).ok();
     let browse_id = mrlir.take_value_pointer(NAVIGATION_BROWSE_ID)?;
@@ -498,11 +507,11 @@ fn parse_artist_search_result_from_music_shelf_contents(
         browse_id,
     })
 }
-// TODO: Type safety
 // TODO: Tests
 fn parse_profile_search_result_from_mrlir(
-    MusicResponsiveListItemRenderer(mut mrlir): MusicResponsiveListItemRenderer,
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultProfile> {
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let username = parse_flex_column_item(&mut mrlir, 1, 2)?;
     let profile_id = mrlir.take_value_pointer(NAVIGATION_BROWSE_ID)?;
@@ -514,12 +523,11 @@ fn parse_profile_search_result_from_mrlir(
         thumbnails,
     })
 }
-// TODO: Type safety
 // TODO: Tests
-fn parse_album_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_album_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultAlbum> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let album_type = parse_flex_column_item(&mut mrlir, 1, 0)?;
 
@@ -560,8 +568,8 @@ fn parse_album_search_result_from_music_shelf_contents(
         explicit,
     })
 }
-fn parse_song_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_song_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultSong> {
     // The byline comprises multiple fields delimited by " • ".
     // See https://github.com/nick42d/youtui/issues/171.
@@ -596,7 +604,7 @@ fn parse_song_search_result_from_music_shelf_contents(
         Ok(Some((artist, None, album_or_duration)))
     }
 
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
 
     let (artist, album, duration) = mrlir
@@ -626,12 +634,11 @@ fn parse_song_search_result_from_music_shelf_contents(
         duration,
     })
 }
-// TODO: Type safety
 // TODO: Tests
-fn parse_video_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_video_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<Option<SearchResultVideo>> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     // Handle not available case
     if let Ok("MUSIC_ITEM_RENDERER_DISPLAY_POLICY_GREY_OUT") = mrlir
         .take_value_pointer::<String>(DISPLAY_POLICY)
@@ -706,12 +713,11 @@ fn parse_video_search_result_from_music_shelf_contents(
         }
     }
 }
-// TODO: Type safety
 // TODO: Tests
-fn parse_podcast_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_podcast_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultPodcast> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let publisher = parse_flex_column_item(&mut mrlir, 1, 0)?;
     let podcast_id = mrlir.take_value_pointer(NAVIGATION_BROWSE_ID)?;
@@ -723,12 +729,11 @@ fn parse_podcast_search_result_from_music_shelf_contents(
         thumbnails,
     })
 }
-// TODO: Type safety
 // TODO: Tests
-fn parse_episode_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_episode_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultEpisode> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let date = if mrlir.path_exists(LIVE_BADGE_LABEL) {
         EpisodeDate::Live
@@ -751,12 +756,11 @@ fn parse_episode_search_result_from_music_shelf_contents(
         thumbnails,
     })
 }
-// TODO: Type safety
 // TODO: Tests
-fn parse_featured_playlist_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_featured_playlist_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultFeaturedPlaylist> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let author = parse_flex_column_item(&mut mrlir, 1, 0)?;
     let songs = parse_flex_column_item(&mut mrlir, 1, 2)?;
@@ -770,25 +774,25 @@ fn parse_featured_playlist_search_result_from_music_shelf_contents(
         thumbnails,
     })
 }
-fn parse_community_playlist_basic_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_community_playlist_basic_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<BasicSearchResultCommunityPlaylist> {
-    let result_type: YoutubeMusicPageType = music_shelf_contents
-        .borrow_value_pointer(concatcp!(MRLIR, NAVIGATION_BROWSE, PAGE_TYPE))?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
+    let result_type = mrlir.borrow_value_pointer(concatcp!(NAVIGATION_BROWSE, PAGE_TYPE))?;
     let result = match result_type {
         YoutubeMusicPageType::Podcast => BasicSearchResultCommunityPlaylist::Podcast(
-            parse_podcast_search_result_from_music_shelf_contents(music_shelf_contents)?,
+            parse_podcast_search_result_from_mrlir(mrlir)?,
         ),
         YoutubeMusicPageType::Playlist => BasicSearchResultCommunityPlaylist::Playlist(
-            parse_community_playlist_search_result_from_music_shelf_contents(music_shelf_contents)?,
+            parse_community_playlist_search_result_from_mrlir(mrlir)?,
         ),
     };
     Ok(result)
 }
-fn parse_community_playlist_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_community_playlist_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultCommunityPlaylist> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let author = parse_flex_column_item(&mut mrlir, 1, 0)?;
     let views = parse_flex_column_item(&mut mrlir, 1, 2)?;
@@ -803,37 +807,32 @@ fn parse_community_playlist_search_result_from_music_shelf_contents(
     })
 }
 
-fn parse_playlist_search_result_from_music_shelf_contents(
-    mut music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_playlist_search_result_from_mrlir(
+    mrlir: MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultPlaylist> {
-    let result_type: YoutubeMusicPageType = music_shelf_contents
-        .borrow_value_pointer(concatcp!(MRLIR, NAVIGATION_BROWSE, PAGE_TYPE))?;
+    let MusicResponsiveListItemRenderer(mut mrlir) = mrlir;
+    let result_type: YoutubeMusicPageType =
+        mrlir.borrow_value_pointer(concatcp!(NAVIGATION_BROWSE, PAGE_TYPE))?;
 
     // Search result for this query can be Podcast or Playlist.
     match result_type {
         YoutubeMusicPageType::Podcast => {
-            let res = parse_podcast_search_result_from_music_shelf_contents(music_shelf_contents)?;
+            let res = parse_podcast_search_result_from_mrlir(mrlir)?;
             Ok(SearchResultPlaylist::Podcast(res))
         }
         YoutubeMusicPageType::Playlist => {
             // The playlist search contains a mix of Community and Featured playlists.
-            let playlist_params: PlaylistEndpointParams =
-                music_shelf_contents.take_value_pointer(concatcp!(
-                    MRLIR,
-                    PLAY_BUTTON,
-                    "/playNavigationEndpoint/watchPlaylistEndpoint/params"
-                ))?;
+            let playlist_params: PlaylistEndpointParams = mrlir.take_value_pointer(concatcp!(
+                PLAY_BUTTON,
+                "/playNavigationEndpoint/watchPlaylistEndpoint/params"
+            ))?;
             let playlist = match playlist_params {
                 PlaylistEndpointParams::Featured => {
-                    let res = parse_featured_playlist_search_result_from_music_shelf_contents(
-                        music_shelf_contents,
-                    )?;
+                    let res = parse_featured_playlist_search_result_from_mrlir(mrlir)?;
                     SearchResultPlaylist::Featured(res)
                 }
                 PlaylistEndpointParams::Community => {
-                    let res = parse_community_playlist_search_result_from_music_shelf_contents(
-                        music_shelf_contents,
-                    )?;
+                    let res = parse_community_playlist_search_result_from_mrlir(mrlir)?;
                     SearchResultPlaylist::Community(res)
                 }
             };
@@ -923,17 +922,15 @@ impl<'a, F: FilteredSearchType> TryFrom<ProcessedResult<'a, SearchQuery<'a, Filt
         Ok(FilteredSearchSectionContents(section_contents))
     }
 }
+fn get_mrlir_at_location(location: JsonCrawlerOwned) -> Result<MusicResponsiveListItemRenderer> {
+    location
+        .navigate_pointer(MRLIR)
+        .map_err(Into::into)
+        .map(MusicResponsiveListItemRenderer)
+}
 fn get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
     mut section_contents: FilteredSearchSectionContents,
 ) -> Result<impl Iterator<Item = Result<MusicResponsiveListItemRenderer>>> {
-    fn get_mrlir_at_location(
-        location: JsonCrawlerOwned,
-    ) -> Result<MusicResponsiveListItemRenderer> {
-        location
-            .navigate_pointer(MRLIR)
-            .map_err(Into::into)
-            .map(MusicResponsiveListItemRenderer)
-    }
     let parsers: [fn(&mut JsonCrawlerOwned) -> _; 2] = [
         |contents| {
             let iter = contents
@@ -968,7 +965,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultAlbum> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_album_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_album_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -994,7 +991,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultArtist> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_artist_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_artist_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1007,7 +1004,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultSong> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_song_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_song_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1020,7 +1017,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultVideo> {
         value
             .0
             .try_iter_mut()?
-            .filter_map(|a| parse_video_search_result_from_music_shelf_contents(a).transpose())
+            .filter_map(|a| parse_video_search_result_from_mrlir(a).transpose())
             .collect()
     }
 }
@@ -1033,7 +1030,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultEpisode> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_episode_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_episode_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1046,7 +1043,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultPodcast> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_podcast_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_podcast_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1059,7 +1056,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultPlaylist> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_playlist_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_playlist_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1072,7 +1069,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultCommunityPlay
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_community_playlist_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_community_playlist_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1085,7 +1082,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultFeaturedPlayl
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_featured_playlist_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_featured_playlist_search_result_from_mrlir(a))
             .collect()
     }
 }

--- a/ytmapi-rs/src/parse/search.rs
+++ b/ytmapi-rs/src/parse/search.rs
@@ -23,9 +23,7 @@ use crate::youtube_enums::{PlaylistEndpointParams, YoutubeMusicPageType};
 use crate::{Error, Result};
 use const_format::concatcp;
 use itertools::{Either, Itertools};
-use json_crawler::{
-    CrawlerResult, JsonCrawler, JsonCrawlerBorrowed, JsonCrawlerIterator, JsonCrawlerOwned,
-};
+use json_crawler::{JsonCrawler, JsonCrawlerBorrowed, JsonCrawlerIterator, JsonCrawlerOwned};
 use serde::de::IntoDeserializer;
 use serde::{Deserialize, Serialize};
 
@@ -331,7 +329,7 @@ fn parse_basic_search_result_from_section_list_contents(
                 profiles = category
                     .navigate_pointer("/contents")?
                     .try_iter_mut()?
-                    .map(|r| parse_profile_search_result_from_music_shelf_contents(r))
+                    .map(|r| parse_profile_search_result_from_mrlir(r))
                     .collect::<Result<Vec<SearchResultProfile>>>()?
             }
         }
@@ -502,10 +500,9 @@ fn parse_artist_search_result_from_music_shelf_contents(
 }
 // TODO: Type safety
 // TODO: Tests
-fn parse_profile_search_result_from_music_shelf_contents(
-    music_shelf_contents: JsonCrawlerBorrowed<'_>,
+fn parse_profile_search_result_from_mrlir(
+    MusicResponsiveListItemRenderer(mut mrlir): MusicResponsiveListItemRenderer,
 ) -> Result<SearchResultProfile> {
-    let mut mrlir = music_shelf_contents.navigate_pointer("/musicResponsiveListItemRenderer")?;
     let title = parse_flex_column_item(&mut mrlir, 0, 0)?;
     let username = parse_flex_column_item(&mut mrlir, 1, 2)?;
     let profile_id = mrlir.take_value_pointer(NAVIGATION_BROWSE_ID)?;
@@ -846,7 +843,6 @@ fn parse_playlist_search_result_from_music_shelf_contents(
 }
 
 struct FilteredSearchSectionContents(JsonCrawlerOwned);
-struct FilteredSearchMusicShelfContents(JsonCrawlerOwned);
 struct MusicResponsiveListItemRenderer(JsonCrawlerOwned);
 struct BasicSearchSectionListContents(JsonCrawlerOwned);
 // In this case, we've searched and had no results found.
@@ -927,16 +923,17 @@ impl<'a, F: FilteredSearchType> TryFrom<ProcessedResult<'a, SearchQuery<'a, Filt
         Ok(FilteredSearchSectionContents(section_contents))
     }
 }
-fn get_mrlir_at_location(
-    location: JsonCrawlerOwned,
-) -> json_crawler::CrawlerResult<MusicResponsiveListItemRenderer> {
-    location
-        .navigate_pointer(MRLIR)
-        .map(MusicResponsiveListItemRenderer)
-}
 fn get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
     mut section_contents: FilteredSearchSectionContents,
-) -> Result<impl Iterator<Item = json_crawler::CrawlerResult<MusicResponsiveListItemRenderer>>> {
+) -> Result<impl Iterator<Item = Result<MusicResponsiveListItemRenderer>>> {
+    fn get_mrlir_at_location(
+        location: JsonCrawlerOwned,
+    ) -> Result<MusicResponsiveListItemRenderer> {
+        location
+            .navigate_pointer(MRLIR)
+            .map_err(Into::into)
+            .map(MusicResponsiveListItemRenderer)
+    }
     let parsers: [fn(&mut JsonCrawlerOwned) -> _; 2] = [
         |contents| {
             let iter = contents
@@ -945,14 +942,15 @@ fn get_music_responsive_list_item_renderers_from_filtered_search_section_content
                 .take_crawler()
                 .try_into_iter()?
                 .map(get_mrlir_at_location);
-            Ok(Either::left(iter))
+            Ok(Either::Left(iter))
         },
         |contents| {
             let iter = contents
-                .try_iter_mut()?
-                .map(|content| content.navigate_pointer("/itemSectionRenderer/contents/0"))
-                .map(|maybe_content| maybe_content.map(JsonCrawlerBorrowed::take_crawler))
-                .map(|maybe_content| maybe_content.map(get_mrlir_at_location));
+                .borrow_mut()
+                .take_crawler()
+                .try_into_iter()?
+                .map(|content| Ok(content.navigate_pointer("/itemSectionRenderer/contents/0")?))
+                .map(|maybe_content| maybe_content.and_then(get_mrlir_at_location));
             Ok(Either::Right(iter))
         },
     ];
@@ -960,18 +958,6 @@ fn get_music_responsive_list_item_renderers_from_filtered_search_section_content
         .0
         .try_functions(parsers)
         .map_err(Into::into)
-}
-impl TryFrom<FilteredSearchSectionContents> for FilteredSearchMusicShelfContents {
-    type Error = Error;
-    fn try_from(
-        value: FilteredSearchSectionContents,
-    ) -> std::prelude::v1::Result<Self, Self::Error> {
-        let music_shelf_contents = value
-            .0
-            .try_into_iter()?
-            .find_path(concatcp!(MUSIC_SHELF, "/contents"))?;
-        Ok(FilteredSearchMusicShelfContents(music_shelf_contents))
-    }
 }
 impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultAlbum> {
     type Error = Error;
@@ -995,7 +981,7 @@ impl TryFrom<FilteredSearchMusicShelfContents> for Vec<SearchResultProfile> {
         value
             .0
             .try_iter_mut()?
-            .map(|a| parse_profile_search_result_from_music_shelf_contents(a))
+            .map(|a| parse_profile_search_result_from_mrlir(a))
             .collect()
     }
 }
@@ -1152,7 +1138,12 @@ impl<'a> ParseFromContinuable<SearchQuery<'a, FilteredSearch<ProfilesFilter>>>
         }
         let continuation_params =
             take_continuation_params_from_section_contents(&mut section_contents)?;
-        let results = FilteredSearchMusicShelfContents::try_from(section_contents)?.try_into()?;
+        let results =
+            get_music_responsive_list_item_renderers_from_filtered_search_section_contents(
+                section_contents,
+            )?
+            .map(|maybe_mrlir| maybe_mrlir.and_then(parse_profile_search_result_from_mrlir))
+            .collect()?;
         Ok((results, continuation_params))
     }
     fn parse_continuation(

--- a/ytmapi-rs/src/parse/search/tests.rs
+++ b/ytmapi-rs/src/parse/search/tests.rs
@@ -70,7 +70,7 @@ async fn test_search_artists_empty() {
         .await
         .expect("Expect file read to pass during tests");
     // Blank query has no bearing on function
-    let query = SearchQuery::new("").with_filter(ArtistsFilter);
+    let query = SearchQuery::new_filtered("", ArtistsFilter);
     let output = process_json::<_, BrowserToken>(source, query).unwrap();
     assert_eq!(output, Vec::new());
 }

--- a/ytmapi-rs/src/parse/search/tests.rs
+++ b/ytmapi-rs/src/parse/search/tests.rs
@@ -170,7 +170,7 @@ async fn test_search_artists() {
         "./test_json/search_artists_20231226.json",
         "./test_json/search_artists_continuation_20231226.json",
         "./test_json/search_artists_20231226_output.txt",
-        SearchQuery::new("").with_filter(ArtistsFilter),
+        SearchQuery::new_filtered("", ArtistsFilter),
         BrowserToken
     );
 }
@@ -179,7 +179,7 @@ async fn test_search_artists_with_about_message() {
     parse_test!(
         "./test_json/search_artists_with_about_message_20240824.json",
         "./test_json/search_artists_with_about_message_20240824_output.txt",
-        SearchQuery::new("").with_filter(ArtistsFilter),
+        SearchQuery::new_filtered("", ArtistsFilter),
         BrowserToken
     );
 }
@@ -189,7 +189,7 @@ async fn test_search_albums() {
         "./test_json/search_albums_20231226.json",
         "./test_json/search_albums_continuation_20231226.json",
         "./test_json/search_albums_20231226_output.txt",
-        SearchQuery::new("").with_filter(AlbumsFilter),
+        SearchQuery::new_filtered("", AlbumsFilter),
         BrowserToken
     );
 }
@@ -199,7 +199,16 @@ async fn test_search_songs() {
         "./test_json/search_songs_20231226.json",
         "./test_json/search_songs_continuation_20231226.json",
         "./test_json/search_songs_20231226_output.txt",
-        SearchQuery::new("").with_filter(SongsFilter),
+        SearchQuery::new_filtered("", SongsFilter),
+        BrowserToken
+    );
+}
+#[tokio::test]
+async fn test_search_songs_2026() {
+    parse_test!(
+        "./test_json/search_songs_generated_to_be_replaced_20260616.json",
+        "./test_json/search_songs_20231226_output.txt",
+        SearchQuery::new_filtered("", SongsFilter),
         BrowserToken
     );
 }
@@ -208,7 +217,7 @@ async fn test_search_videos() {
     parse_test!(
         "./test_json/search_videos_20231226.json",
         "./test_json/search_videos_20231226_output.txt",
-        SearchQuery::new("").with_filter(VideosFilter),
+        SearchQuery::new_filtered("", VideosFilter),
         BrowserToken
     );
 }
@@ -219,7 +228,7 @@ async fn test_search_videos_2024() {
         "./test_json/search_videos_20240612.json",
         "./test_json/search_videos_continuation_20240612.json",
         "./test_json/search_videos_20240612_output.txt",
-        SearchQuery::new("").with_filter(VideosFilter),
+        SearchQuery::new_filtered("", VideosFilter),
         BrowserToken
     );
 }
@@ -229,7 +238,7 @@ async fn test_search_playlists() {
         "./test_json/search_playlists_20231228.json",
         "./test_json/search_playlists_continuation_20231228.json",
         "./test_json/search_playlists_20231228_output.txt",
-        SearchQuery::new("").with_filter(PlaylistsFilter),
+        SearchQuery::new_filtered("", PlaylistsFilter),
         BrowserToken
     );
 }
@@ -239,7 +248,7 @@ async fn test_search_featured_playlists() {
         "./test_json/search_featured_playlists_20231226.json",
         "./test_json/search_featured_playlists_continuation_20231226.json",
         "./test_json/search_featured_playlists_20231226_output.txt",
-        SearchQuery::new("").with_filter(FeaturedPlaylistsFilter),
+        SearchQuery::new_filtered("", FeaturedPlaylistsFilter),
         BrowserToken
     );
 }
@@ -249,7 +258,7 @@ async fn test_search_community_playlists() {
         "./test_json/search_community_playlists_20231226.json",
         "./test_json/search_community_playlists_continuation_20231226.json",
         "./test_json/search_community_playlists_20231226_output.txt",
-        SearchQuery::new("").with_filter(CommunityPlaylistsFilter),
+        SearchQuery::new_filtered("", CommunityPlaylistsFilter),
         BrowserToken
     );
 }
@@ -259,7 +268,7 @@ async fn test_search_episodes() {
         "./test_json/search_episodes_20231226.json",
         "./test_json/search_episodes_continuation_20231226.json",
         "./test_json/search_episodes_20231226_output.txt",
-        SearchQuery::new("").with_filter(EpisodesFilter),
+        SearchQuery::new_filtered("", EpisodesFilter),
         BrowserToken
     );
 }
@@ -269,7 +278,7 @@ async fn test_search_podcasts() {
         "./test_json/search_podcasts_20231226.json",
         "./test_json/search_podcasts_continuation_20231226.json",
         "./test_json/search_podcasts_20231226_output.txt",
-        SearchQuery::new("").with_filter(PodcastsFilter),
+        SearchQuery::new_filtered("", PodcastsFilter),
         BrowserToken
     );
 }
@@ -279,7 +288,7 @@ async fn test_search_profiles() {
         "./test_json/search_profiles_20231226.json",
         "./test_json/search_profiles_continuation_20231226.json",
         "./test_json/search_profiles_20231226_output.txt",
-        SearchQuery::new("").with_filter(ProfilesFilter),
+        SearchQuery::new_filtered("", ProfilesFilter),
         BrowserToken
     );
 }

--- a/ytmapi-rs/test_json/search_songs_generated_to_be_replaced_20260616.json
+++ b/ytmapi-rs/test_json/search_songs_generated_to_be_replaced_20260616.json
@@ -1,0 +1,10986 @@
+{
+  "contents": {
+    "tabbedSearchResultsRenderer": {
+      "tabs": [
+        {
+          "tabRenderer": {
+            "title": "YT\u00a0Music",
+            "selected": true,
+            "content": {
+              "sectionListRenderer": {
+                "contents": [
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CK4CEOFnGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/lNd64sU8cAboiAZ0HVcYg-TWc5wS8TTKpqQUR3w0z3_r0nZ9uqEfJRxdJ0y1SdDdoVKXCO2arS3SuBLvng=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/lNd64sU8cAboiAZ0HVcYg-TWc5wS8TTKpqQUR3w0z3_r0nZ9uqEfJRxdJ0y1SdDdoVKXCO2arS3SuBLvng=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CLwCEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CLsCEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "fOjuqmZzul4",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CLsCEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Now And Then - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Now And Then - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Now And Then",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CK4CEOFnGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "fOjuqmZzul4",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CK4CEOFnGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_oloYR7Vz0y8",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "4:09"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "55M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLoCEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "fOjuqmZzul4",
+                                          "playlistId": "RDAMVMfOjuqmZzul4",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1mT2p1cW1aenVsNA%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLoCEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CLgCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "fOjuqmZzul4",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CLgCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "fOjuqmZzul4"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CLgCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CLkCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CLgCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CLYCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "fOjuqmZzul4",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CLYCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "fOjuqmZzul4"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CLYCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CLcCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CLYCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CLUCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKFNg2Iugi2YTfDsp3GVLeNZ6qPWUwq6MUeibWWLEXfXeJUSEChW1ZHHUfJk_aBreVReCWsUNYqV77yUREs7ZqNriulBw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CLUCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpI88eTeerUOOoWktvoFDM8qTyC4Oa5Qs0ayPve2jreUFd9gjCIAjM89h_CprgchPzq62cbl4b-2AT8AvkN-CZAtBUMumA"
+                                        }
+                                      },
+                                      "trackingParams": "CLUCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CLQCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "fOjuqmZzul4"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CLQCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpKFNg2Iugi2YTfDsp3GVLeNZ6qPWUwq6MUeibWWLEXfXeJUSEChW1ZHHUfJk_aBreVReCWsUNYqV77yUREs7ZqNriulBw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CLQCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "fOjuqmZzul4"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLQCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLMCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "fOjuqmZzul4"
+                                        }
+                                      },
+                                      "trackingParams": "CLMCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLICEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_oloYR7Vz0y8",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLICEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLECEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLECEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLACEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtmT2p1cW1aenVsNA%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CLACEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CK8CEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "fOjuqmZzul4"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CMcCEOFnGAAiEwi99-jvrKSJAxVILrcAHWQJES4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/SdV90lGM_wxu3dzLlc6kEhENt6vRBO-TwCAnzKCI-8cslYXnHOUC9u91g4cj3ZkrKAZySFKN6r5z7L3e=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/SdV90lGM_wxu3dzLlc6kEhENt6vRBO-TwCAnzKCI-8cslYXnHOUC9u91g4cj3ZkrKAZySFKN6r5z7L3e=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CNcCEIS_AiITCL336O-spIkDFUgutwAdZAkRLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CNYCEMjeAiITCL336O-spIkDFUgutwAdZAkRLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "bNNl8VOjbcY",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CNYCEMjeAiITCL336O-spIkDFUgutwAdZAkRLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 14745645,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Sleeping in the Cold Below (From \"Warframe\") - Keith Power"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Sleeping in the Cold Below (From \"Warframe\") - Keith Power"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Sleeping in the Cold Below (From \"Warframe\") (feat. Damhnait Doyle)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMcCEOFnGAAiEwi99-jvrKSJAxVILrcAHWQJES6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "bNNl8VOjbcY",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Keith Power",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMcCEOFnGAAiEwi99-jvrKSJAxVILrcAHWQJES4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UCm-7mqcQi6y-DEJAE0lOcyA",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " & "
+                                      },
+                                      {
+                                        "text": "Alan Doyle",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMcCEOFnGAAiEwi99-jvrKSJAxVILrcAHWQJES4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UCzK2N8Mjnz_rUxdwPGPJVMA",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Sleeping in the Cold Below (From \"Warframe\")",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMcCEOFnGAAiEwi99-jvrKSJAxVILrcAHWQJES4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_zjKqlIlmFnG",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "3:32"
+                                      }
+                                    ],
+                                    "accessibility": {
+                                      "accessibilityData": {
+                                        "label": "Keith Power & Alan Doyle \u2022 Sleeping in the Cold Below (From \"Warframe\") \u2022 3 minutes, 32 seconds"
+                                      }
+                                    }
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "5M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CNUCEJvzBRgAIhMIvffo76ykiQMVSC63AB1kCREumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "bNNl8VOjbcY",
+                                          "playlistId": "RDAMVMbNNl8VOjbcY",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1iTk5sOFZPamJjWQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CNUCEJvzBRgAIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CNMCEL7uBRgBIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "bNNl8VOjbcY",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CNMCEL7uBRgBIhMIvffo76ykiQMVSC63AB1kCREu",
+                                              "watchEndpoint": {
+                                                "videoId": "bNNl8VOjbcY"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CNMCEL7uBRgBIhMIvffo76ykiQMVSC63AB1kCREu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CNQCEMrHAyITCL336O-spIkDFUgutwAdZAkRLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CNMCEL7uBRgBIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CNECEPvvBRgCIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "bNNl8VOjbcY",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CNECEPvvBRgCIhMIvffo76ykiQMVSC63AB1kCREu",
+                                              "watchEndpoint": {
+                                                "videoId": "bNNl8VOjbcY"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CNECEPvvBRgCIhMIvffo76ykiQMVSC63AB1kCREu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CNICEMrHAyITCL336O-spIkDFUgutwAdZAkRLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CNECEPvvBRgCIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CNACEIT_BRgDIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIrt_FjC43lACBKzeUZBSkTviXbEtKczPGdimc_71yp4ma2VmIRmtBGcmer60K_clrhvtfpGzzmi95p5RAUkYuoDSEzaA"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CNACEIT_BRgDIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpL6SEIfthFQGiaWPjDbvLhemFq4t71Vlo9x2pn5ZPNYECkhOl6mhNAXSUr2DfArnl9ebUQ0ADHlbcoTydUuNMSPDI8Kzg"
+                                        }
+                                      },
+                                      "trackingParams": "CNACEIT_BRgDIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CM8CEIyfBhgEIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "bNNl8VOjbcY"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CM8CEIyfBhgEIhMIvffo76ykiQMVSC63AB1kCREu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpIrt_FjC43lACBKzeUZBSkTviXbEtKczPGdimc_71yp4ma2VmIRmtBGcmer60K_clrhvtfpGzzmi95p5RAUkYuoDSEzaA"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CM8CEIyfBhgEIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "bNNl8VOjbcY"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CM8CEIyfBhgEIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemDownloadRenderer": {
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CM4CENGqBRgFIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "offlineVideoEndpoint": {
+                                          "videoId": "bNNl8VOjbcY",
+                                          "onAddCommand": {
+                                            "clickTrackingParams": "CM4CENGqBRgFIhMIvffo76ykiQMVSC63AB1kCREu",
+                                            "getDownloadActionCommand": {
+                                              "videoId": "bNNl8VOjbcY",
+                                              "params": "CAI%3D"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CM4CENGqBRgFIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CM0CEMOUBhgGIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "bNNl8VOjbcY"
+                                        }
+                                      },
+                                      "trackingParams": "CM0CEMOUBhgGIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMwCEI_7BRgHIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_zjKqlIlmFnG",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMwCEI_7BRgHIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMsCEJD7BRgIIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "browseEndpoint": {
+                                          "browseId": "UCm-7mqcQi6y-DEJAE0lOcyA",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMsCEJD7BRgIIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "View song credits"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "PEOPLE_GROUP"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMoCEK-jChgJIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPTCbNNl8VOjbcY",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_TRACK_CREDITS"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMoCEK-jChgJIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMkCEJH7BRgKIhMIvffo76ykiQMVSC63AB1kCREu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtiTk5sOFZPamJjWQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CMkCEJH7BRgKIhMIvffo76ykiQMVSC63AB1kCREu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CMgCEKc7IhMIvffo76ykiQMVSC63AB1kCREu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "bNNl8VOjbcY"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CJ8CEOFnGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/CbjJQRLZjUS9jvX3VDtjxk0CtpF_izoi8uEkvKKcnYOrDjNlsZhi7LmdoUFdnGrJH686mTICLZKOhrHLKw=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/CbjJQRLZjUS9jvX3VDtjxk0CtpF_izoi8uEkvKKcnYOrDjNlsZhi7LmdoUFdnGrJH686mTICLZKOhrHLKw=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CK0CEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CKwCEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "uxb_mysjpFM",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CKwCEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Ticket To Ride (2023 Mix) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Ticket To Ride (2023 Mix) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Ticket To Ride (2023 Mix)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJ8CEOFnGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "uxb_mysjpFM",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJ8CEOFnGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "The Beatles 1962 \u2013 1966 (2023 Edition)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJ8CEOFnGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_4f3MInKb7OW",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "3:12"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "99M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKsCEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "uxb_mysjpFM",
+                                          "playlistId": "RDAMVMuxb_mysjpFM",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk11eGJfbXlzanBGTQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKsCEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CKkCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "uxb_mysjpFM",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CKkCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "uxb_mysjpFM"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CKkCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CKoCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CKkCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CKcCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "uxb_mysjpFM",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CKcCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "uxb_mysjpFM"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CKcCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CKgCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CKcCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CKYCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJ3n_m1VkyXhe3hgitVEgkNoMu-iffmDI_IS9FgY8qREVOXXIrf54IZntRqvUzU9EuWM24hD9wkJ4G0yewto_qniT8XUQ"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CKYCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKPOsWPXHuRGpUKC23CkAQk1MHDZAIxznRwvhGSd2M56euhU9CCUpf6tIUuaNHViZ00Hgq6CTy0yTpuf4dq55xuqzbUqg"
+                                        }
+                                      },
+                                      "trackingParams": "CKYCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CKUCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "uxb_mysjpFM"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CKUCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJ3n_m1VkyXhe3hgitVEgkNoMu-iffmDI_IS9FgY8qREVOXXIrf54IZntRqvUzU9EuWM24hD9wkJ4G0yewto_qniT8XUQ"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CKUCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "uxb_mysjpFM"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKUCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKQCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "uxb_mysjpFM"
+                                        }
+                                      },
+                                      "trackingParams": "CKQCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKMCEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_4f3MInKb7OW",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKMCEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKICEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKICEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKECEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgt1eGJfbXlzanBGTQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CKECEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CKACEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "uxb_mysjpFM"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CJACEOFnGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/ZMbbfFua2T4giKdxPw32r1LAOqJit-yhjneipMCSl07-WCHmx6Gz5lENjMh7jZ_-0K3KVR7FLb5HUQ=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/ZMbbfFua2T4giKdxPw32r1LAOqJit-yhjneipMCSl07-WCHmx6Gz5lENjMh7jZ_-0K3KVR7FLb5HUQ=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CJ4CEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CJ0CEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "4DLOnGCPr4g",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CJ0CEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Don't Let Me Down (Rooftop Performance / Take 2) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Don't Let Me Down (Rooftop Performance / Take 2) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Don't Let Me Down (Rooftop Performance / Take 2)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJACEOFnGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "4DLOnGCPr4g",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJACEOFnGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Get Back (Rooftop Performance)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJACEOFnGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_ldG5NfPZGl1",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "3:30"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "1.2M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJwCEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "4DLOnGCPr4g",
+                                          "playlistId": "RDAMVM4DLOnGCPr4g",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk00RExPbkdDUHI0Zw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJwCEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CJoCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "4DLOnGCPr4g",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CJoCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "4DLOnGCPr4g"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CJoCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CJsCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CJoCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CJgCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "4DLOnGCPr4g",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CJgCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "4DLOnGCPr4g"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CJgCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CJkCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CJgCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CJcCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKzHwSNoWdVNE7lByVfsTWi7-UzDcivdElqAJg2mNUGWE7nlzxy55BXELmqULXBD88QvFy5cUVXYqE5XNBLYa5R75Z5Tw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CJcCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJGL4flBxChne4LTLzy0GEyCGa34Mdz9oULVC1uvMkikGoZ5g_klEVEf2i2y1ZwHrxKlH_71__ZjxfVyBKhm0J-SHwKTg"
+                                        }
+                                      },
+                                      "trackingParams": "CJcCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CJYCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "4DLOnGCPr4g"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CJYCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpKzHwSNoWdVNE7lByVfsTWi7-UzDcivdElqAJg2mNUGWE7nlzxy55BXELmqULXBD88QvFy5cUVXYqE5XNBLYa5R75Z5Tw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CJYCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "4DLOnGCPr4g"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJYCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJUCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "4DLOnGCPr4g"
+                                        }
+                                      },
+                                      "trackingParams": "CJUCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJQCEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_ldG5NfPZGl1",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJQCEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJMCEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJMCEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJICEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgs0RExPbkdDUHI0Zw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CJICEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CJECEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "4DLOnGCPr4g"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CIECEOFnGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/bmG1q9eu3ub2CtYcgArvzpiehqUpZGuLsOa_B0Bxkwxdfsk9r7nRzAQy1P5dTjqerODLxq3LycWGWW5m=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/bmG1q9eu3ub2CtYcgArvzpiehqUpZGuLsOa_B0Bxkwxdfsk9r7nRzAQy1P5dTjqerODLxq3LycWGWW5m=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CI8CEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CI4CEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "tAe2Q_LhY8g",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CI4CEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play I Want You (She's So Heavy) (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause I Want You (She's So Heavy) (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "I Want You (She's So Heavy) (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CIECEOFnGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "tAe2Q_LhY8g",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CIECEOFnGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Abbey Road",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CIECEOFnGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_pyQa1mky9hE",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "7:48"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "48M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CI0CEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "tAe2Q_LhY8g",
+                                          "playlistId": "RDAMVMtAe2Q_LhY8g",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk10QWUyUV9MaFk4Zw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CI0CEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CIsCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "tAe2Q_LhY8g",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CIsCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "tAe2Q_LhY8g"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CIsCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CIwCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CIsCEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CIkCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "tAe2Q_LhY8g",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CIkCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "tAe2Q_LhY8g"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CIkCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CIoCEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CIkCEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CIgCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLGFGpsuMjtOr1sEr85JseKTRFadaErv1MgaDmUPIq5bR-sHg-Rb4wb9A73uc6ioQWEcx6Cq84waTW6IRAg9J7gPk9nYQ"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CIgCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIVdtcz8781aFNsHHMKXemI0yZ4pAl5KB_tlSguJuETnN5vG9ATmRShA-8nx3L0qeSQ4AMqiOYZphsCRyQnuWcsoE3V5w"
+                                        }
+                                      },
+                                      "trackingParams": "CIgCEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CIcCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "tAe2Q_LhY8g"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CIcCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpLGFGpsuMjtOr1sEr85JseKTRFadaErv1MgaDmUPIq5bR-sHg-Rb4wb9A73uc6ioQWEcx6Cq84waTW6IRAg9J7gPk9nYQ"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CIcCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "tAe2Q_LhY8g"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CIcCEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIYCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "tAe2Q_LhY8g"
+                                        }
+                                      },
+                                      "trackingParams": "CIYCEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIUCEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_pyQa1mky9hE",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CIUCEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIQCEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CIQCEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIMCEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgt0QWUyUV9MaFk4Zw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CIMCEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CIICEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "tAe2Q_LhY8g"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CPIBEOFnGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/KS07aBkgPPReRdSFphMz-73Fp7_Bu84wnThUnN0THFAQJxpegt_Yhykr2DyKs5mOcbLV1C0MAc-6YNQ=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/KS07aBkgPPReRdSFphMz-73Fp7_Bu84wnThUnN0THFAQJxpegt_Yhykr2DyKs5mOcbLV1C0MAc-6YNQ=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CIACEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CP8BEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "nYpzRcgsabI",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CP8BEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play What's The New Mary Jane (Anthology 3 Version) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause What's The New Mary Jane (Anthology 3 Version) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "What's The New Mary Jane (Anthology 3 Version)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CPIBEOFnGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "nYpzRcgsabI",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CPIBEOFnGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Anthology 3",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CPIBEOFnGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_UfVa8wUcEDl",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "6:13"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "444K\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CP4BEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "nYpzRcgsabI",
+                                          "playlistId": "RDAMVMnYpzRcgsabI",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1uWXB6UmNnc2FiSQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CP4BEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CPwBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "nYpzRcgsabI",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CPwBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "nYpzRcgsabI"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CPwBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CP0BEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CPwBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CPoBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "nYpzRcgsabI",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CPoBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "nYpzRcgsabI"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CPoBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CPsBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CPoBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CPkBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJOhXNCmuaMqMK2UV520Na3P1f0FPmAndJqIxzMaLFQ5ROcF5tCz9V70jBEhKCXXqoK8n8RXTnK0EoenxajteLCUx5KXQ"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CPkBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIRzELBZQntHboCHV8IRoKvxf-XNRe90plZEUHb2BDdOIAAwT8X81VdEha_GQFt7pXsBFFyBR0DMVux5Xf_T0uVj2inSg"
+                                        }
+                                      },
+                                      "trackingParams": "CPkBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CPgBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "nYpzRcgsabI"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CPgBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJOhXNCmuaMqMK2UV520Na3P1f0FPmAndJqIxzMaLFQ5ROcF5tCz9V70jBEhKCXXqoK8n8RXTnK0EoenxajteLCUx5KXQ"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CPgBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "nYpzRcgsabI"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CPgBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CPcBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "nYpzRcgsabI"
+                                        }
+                                      },
+                                      "trackingParams": "CPcBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CPYBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_UfVa8wUcEDl",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CPYBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CPUBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CPUBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CPQBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtuWXB6UmNnc2FiSQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CPQBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CPMBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "nYpzRcgsabI"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "COMBEOFnGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/QpdkXLA-Uk-rDaYu_Vh4YtMEAtsluGUEee_jNEv5FiUrZsx1ZpezAknb7-d7rb8ySbaXm4FQomjjWw0p=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/QpdkXLA-Uk-rDaYu_Vh4YtMEAtsluGUEee_jNEv5FiUrZsx1ZpezAknb7-d7rb8ySbaXm4FQomjjWw0p=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CPEBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CPABEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "-E5FrFh_ddg",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CPABEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Good Morning Good Morning (Take 8 / Anthology 2 Version) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Good Morning Good Morning (Take 8 / Anthology 2 Version) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Good Morning Good Morning (Take 8 / Anthology 2 Version)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "COMBEOFnGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "-E5FrFh_ddg",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "COMBEOFnGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Anthology 2",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "COMBEOFnGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_r9ehGUcIpog",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:41"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "400K\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CO8BEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "-E5FrFh_ddg",
+                                          "playlistId": "RDAMVM-E5FrFh_ddg",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk0tRTVGckZoX2RkZw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CO8BEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CO0BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "-E5FrFh_ddg",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CO0BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "-E5FrFh_ddg"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CO0BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CO4BEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CO0BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "COsBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "-E5FrFh_ddg",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "COsBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "-E5FrFh_ddg"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "COsBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "COwBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "COsBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "COoBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJDjnuX1DPv_pwBqlP73cKs2V7PdSjf7uW9zmvA8oCXxz9BH05Vr-eLn2fAxu4lrpIYqOjXXEzVMiqcfmvXynOkgYTMXg"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "COoBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJtKKtcP1N0G_WZzWb5PIrXGC_Ti_M0ZsUXbTIz3SMzqXWSlbk2K0A6J-ocBUMyHSeUifjxwKFANGpyuIC9GbZvE9dXUw"
+                                        }
+                                      },
+                                      "trackingParams": "COoBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "COkBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "-E5FrFh_ddg"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "COkBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJDjnuX1DPv_pwBqlP73cKs2V7PdSjf7uW9zmvA8oCXxz9BH05Vr-eLn2fAxu4lrpIYqOjXXEzVMiqcfmvXynOkgYTMXg"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "COkBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "-E5FrFh_ddg"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "COkBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "COgBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "-E5FrFh_ddg"
+                                        }
+                                      },
+                                      "trackingParams": "COgBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "COcBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_r9ehGUcIpog",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "COcBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "COYBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "COYBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "COUBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgstRTVGckZoX2RkZw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "COUBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "COQBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "-E5FrFh_ddg"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CNQBEOFnGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/QpdkXLA-Uk-rDaYu_Vh4YtMEAtsluGUEee_jNEv5FiUrZsx1ZpezAknb7-d7rb8ySbaXm4FQomjjWw0p=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/QpdkXLA-Uk-rDaYu_Vh4YtMEAtsluGUEee_jNEv5FiUrZsx1ZpezAknb7-d7rb8ySbaXm4FQomjjWw0p=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "COIBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "COEBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "fUnBTETLOG0",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "COEBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Only A Northern Song (Anthology 2 Version) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Only A Northern Song (Anthology 2 Version) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Only A Northern Song (Anthology 2 Version)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CNQBEOFnGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "fUnBTETLOG0",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CNQBEOFnGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Anthology 2",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CNQBEOFnGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_r9ehGUcIpog",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:44"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "284K\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "COABEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "fUnBTETLOG0",
+                                          "playlistId": "RDAMVMfUnBTETLOG0",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1mVW5CVEVUTE9HMA%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "COABEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CN4BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "fUnBTETLOG0",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CN4BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "fUnBTETLOG0"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CN4BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CN8BEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CN4BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CNwBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "fUnBTETLOG0",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CNwBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "fUnBTETLOG0"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CNwBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CN0BEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CNwBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CNsBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJKPkgmpv2U3D9ZsgfU6PUNXhHZY1NgrjK4hpbKoSjim2sYmi7fcKFAilrbMUh7D-MQyZn_pVAW39tSMRYlpy4WEcIepA"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CNsBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpI_AC7mendLuqGjHr-hYs016f66YsgAt26XpjCY4dc0Ha7mjCa3d6dUMPlcb2-yP3f_UBwf7X6O8TZzgBeozhUSSHpsOg"
+                                        }
+                                      },
+                                      "trackingParams": "CNsBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CNoBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "fUnBTETLOG0"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CNoBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJKPkgmpv2U3D9ZsgfU6PUNXhHZY1NgrjK4hpbKoSjim2sYmi7fcKFAilrbMUh7D-MQyZn_pVAW39tSMRYlpy4WEcIepA"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CNoBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "fUnBTETLOG0"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CNoBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CNkBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "fUnBTETLOG0"
+                                        }
+                                      },
+                                      "trackingParams": "CNkBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CNgBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_r9ehGUcIpog",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CNgBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CNcBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CNcBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CNYBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtmVW5CVEVUTE9HMA%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CNYBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CNUBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "fUnBTETLOG0"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CMUBEOFnGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/r7FUIs4CwI2tr7vFGnvIo8-EgGLBC7LOh5V3OJOIKEneTOAIhgEbUwHeAPizEa2roidqNYaAK-Su48fP1A=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/r7FUIs4CwI2tr7vFGnvIo8-EgGLBC7LOh5V3OJOIKEneTOAIhgEbUwHeAPizEa2roidqNYaAK-Su48fP1A=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CNMBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CNIBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "4txyItk5lXY",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CNIBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play A Day In The Life (Take 1) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause A Day In The Life (Take 1) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "A Day In The Life (Take 1)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMUBEOFnGAciEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "4txyItk5lXY",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMUBEOFnGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Sgt. Pepper's Lonely Hearts Club Band (Super Deluxe Edition)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CMUBEOFnGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_t8PwSmfjuhs",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "4:42"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "458K\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CNEBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "4txyItk5lXY",
+                                          "playlistId": "RDAMVM4txyItk5lXY",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk00dHh5SXRrNWxYWQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CNEBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CM8BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "4txyItk5lXY",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CM8BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "4txyItk5lXY"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CM8BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CNABEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CM8BEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CM0BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "4txyItk5lXY",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CM0BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "4txyItk5lXY"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CM0BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CM4BEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CM0BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CMwBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIjfBN26YUUEEDT0dMn1wEdg5i09zpURMwukGcK-WiwABbSe2fuSGqJ4KDqM6qN6bRlCtxWhKtL07fJppmZOV02zxlmVA"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CMwBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKDwOsUw2UOcYsLPo_mfEJMsYPtEgqH-IIms-MgpGNI8DNi9-7_fKrP4_eS6JC6Hw6dWwcqeN_r8_tfoA8f2f0EqCUOqw"
+                                        }
+                                      },
+                                      "trackingParams": "CMwBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CMsBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "4txyItk5lXY"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CMsBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpIjfBN26YUUEEDT0dMn1wEdg5i09zpURMwukGcK-WiwABbSe2fuSGqJ4KDqM6qN6bRlCtxWhKtL07fJppmZOV02zxlmVA"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CMsBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "4txyItk5lXY"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMsBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMoBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "4txyItk5lXY"
+                                        }
+                                      },
+                                      "trackingParams": "CMoBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMkBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_t8PwSmfjuhs",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMkBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMgBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMgBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMcBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgs0dHh5SXRrNWxYWQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CMcBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CMYBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "4txyItk5lXY"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CLYBEOFnGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/KS07aBkgPPReRdSFphMz-73Fp7_Bu84wnThUnN0THFAQJxpegt_Yhykr2DyKs5mOcbLV1C0MAc-6YNQ=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/KS07aBkgPPReRdSFphMz-73Fp7_Bu84wnThUnN0THFAQJxpegt_Yhykr2DyKs5mOcbLV1C0MAc-6YNQ=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CMQBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CMMBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "3rs-cFctj6k",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CMMBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play While My Guitar Gently Weeps (Anthology 3 Version) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause While My Guitar Gently Weeps (Anthology 3 Version) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "While My Guitar Gently Weeps (Anthology 3 Version)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CLYBEOFnGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "3rs-cFctj6k",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CLYBEOFnGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Anthology 3",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CLYBEOFnGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_UfVa8wUcEDl",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "3:28"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "3.3M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CMIBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "3rs-cFctj6k",
+                                          "playlistId": "RDAMVM3rs-cFctj6k",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk0zcnMtY0ZjdGo2aw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CMIBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CMABEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "3rs-cFctj6k",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CMABEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "3rs-cFctj6k"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CMABEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CMEBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CMABEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CL4BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "3rs-cFctj6k",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CL4BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "3rs-cFctj6k"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CL4BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CL8BEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CL4BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CL0BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKZ5yPXCt8TDckQK_vlBeZajn8xUn6_yviTV8SAoTRIkJQxVJD7RTR0aUEGYFsjQ0C2GH365ay9rBA2NpFm6lF3UjkWbg"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CL0BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJVCD698PSX9-ZWJglTLi2yzZtw2aPvGU49Jydjha3i9C_6_HxiUzzsQ__cWUu6tJMP40MgjpD493AD3LyMukOvyy4SKQ"
+                                        }
+                                      },
+                                      "trackingParams": "CL0BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CLwBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "3rs-cFctj6k"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CLwBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpKZ5yPXCt8TDckQK_vlBeZajn8xUn6_yviTV8SAoTRIkJQxVJD7RTR0aUEGYFsjQ0C2GH365ay9rBA2NpFm6lF3UjkWbg"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CLwBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "3rs-cFctj6k"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLwBEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLsBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "3rs-cFctj6k"
+                                        }
+                                      },
+                                      "trackingParams": "CLsBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLoBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_UfVa8wUcEDl",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLoBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLkBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLkBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLgBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgszcnMtY0ZjdGo2aw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CLgBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CLcBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "3rs-cFctj6k"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CKcBEOFnGAkiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/IjEb5kMRk7qimcH3BCJaK85pf79X383z5KNrAxJSNOHVWC41_e66Id233ZGj1AQhH1H5AiKxQMEbHPn0=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/IjEb5kMRk7qimcH3BCJaK85pf79X383z5KNrAxJSNOHVWC41_e66Id233ZGj1AQhH1H5AiKxQMEbHPn0=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CLUBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CLQBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "WoBLi5eE-wY",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CLQBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Michelle (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Michelle (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Michelle (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CKcBEOFnGAkiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "WoBLi5eE-wY",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CKcBEOFnGAkiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Rubber Soul",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CKcBEOFnGAkiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_NPpc9jtWHdJ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:43"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "51M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CLMBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "WoBLi5eE-wY",
+                                          "playlistId": "RDAMVMWoBLi5eE-wY",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1Xb0JMaTVlRS13WQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CLMBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CLEBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "WoBLi5eE-wY",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CLEBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "WoBLi5eE-wY"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CLEBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CLIBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CLEBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CK8BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "WoBLi5eE-wY",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CK8BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "WoBLi5eE-wY"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CK8BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CLABEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CK8BEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CK4BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLND6w3jDimT5_fEVMycFtaVInYpTZPMtNYvfXPUoxuCcwv56W0hPoTQfGzP7x7YusW5XpI9dL3T2YPascFoIE9lrV-Yw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CK4BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpL6_yJ-52egwaejNYIRjFoqzkYKrvY9PR7NmySZq1ZfhpA4RjemDFGW13R5ZEmIaCu08RknRKdkH53YdbQcY88gUYPaOg"
+                                        }
+                                      },
+                                      "trackingParams": "CK4BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CK0BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "WoBLi5eE-wY"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CK0BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpLND6w3jDimT5_fEVMycFtaVInYpTZPMtNYvfXPUoxuCcwv56W0hPoTQfGzP7x7YusW5XpI9dL3T2YPascFoIE9lrV-Yw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CK0BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "WoBLi5eE-wY"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CK0BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKwBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "WoBLi5eE-wY"
+                                        }
+                                      },
+                                      "trackingParams": "CKwBEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKsBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_NPpc9jtWHdJ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKsBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKoBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKoBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKkBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtXb0JMaTVlRS13WQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CKkBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CKgBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "WoBLi5eE-wY"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CJgBEOFnGAoiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/O0BM0qveWB40423x8L9AdJxuMcBhFg0x_UtCbFQ_pRwbF412bmnlKj420gEPx1wwwAVpyXHpHp35cAU=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/O0BM0qveWB40423x8L9AdJxuMcBhFg0x_UtCbFQ_pRwbF412bmnlKj420gEPx1wwwAVpyXHpHp35cAU=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CKYBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CKUBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "oVW6wJ7MYDM",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CKUBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Come Together - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Come Together - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Come Together",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJgBEOFnGAoiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "oVW6wJ7MYDM",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJgBEOFnGAoiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "1",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CJgBEOFnGAoiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_mnYrD806fc4",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "4:19"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "243M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CKQBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "oVW6wJ7MYDM",
+                                          "playlistId": "RDAMVMoVW6wJ7MYDM",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1vVlc2d0o3TVlETQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CKQBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CKIBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "oVW6wJ7MYDM",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CKIBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "oVW6wJ7MYDM"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CKIBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CKMBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CKIBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CKABEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "oVW6wJ7MYDM",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CKABEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "oVW6wJ7MYDM"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CKABEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CKEBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CKABEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CJ8BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKfjAkcrDFvdXPHd5ErZ6f6527Z0sIxcZjswSNK-4icV7AH_7guJuxYVAajDzY2sfrpnoyIks8FDrLJ_8Vw61mOvBD6Rw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CJ8BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKRNhmNSdnLHcYYZ8zSz14kHXEGyd9rGvUSrNgYSDxC6kV0xmejwb63tQe_542TWYRZwLT1uDhqD2cNlsBVMVyTFDzxpA"
+                                        }
+                                      },
+                                      "trackingParams": "CJ8BEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CJ4BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "oVW6wJ7MYDM"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CJ4BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpKfjAkcrDFvdXPHd5ErZ6f6527Z0sIxcZjswSNK-4icV7AH_7guJuxYVAajDzY2sfrpnoyIks8FDrLJ_8Vw61mOvBD6Rw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CJ4BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "oVW6wJ7MYDM"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJ4BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJ0BEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "oVW6wJ7MYDM"
+                                        }
+                                      },
+                                      "trackingParams": "CJ0BEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJwBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_mnYrD806fc4",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJwBEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJsBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJsBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJoBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtvVlc2d0o3TVlETQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CJoBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CJkBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "oVW6wJ7MYDM"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CIkBEOFnGAsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/bmG1q9eu3ub2CtYcgArvzpiehqUpZGuLsOa_B0Bxkwxdfsk9r7nRzAQy1P5dTjqerODLxq3LycWGWW5m=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/bmG1q9eu3ub2CtYcgArvzpiehqUpZGuLsOa_B0Bxkwxdfsk9r7nRzAQy1P5dTjqerODLxq3LycWGWW5m=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CJcBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CJYBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "De1LCQvbqV4",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CJYBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Octopus's Garden (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Octopus's Garden (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Octopus's Garden (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CIkBEOFnGAsiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                          "watchEndpoint": {
+                                            "videoId": "De1LCQvbqV4",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CIkBEOFnGAsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Abbey Road",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CIkBEOFnGAsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_pyQa1mky9hE",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:51"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "23M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CJUBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "De1LCQvbqV4",
+                                          "playlistId": "RDAMVMDe1LCQvbqV4",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1EZTFMQ1F2YnFWNA%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CJUBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CJMBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "De1LCQvbqV4",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CJMBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "De1LCQvbqV4"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CJMBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CJQBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CJMBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CJEBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "De1LCQvbqV4",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CJEBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "De1LCQvbqV4"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CJEBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CJIBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CJEBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CJABEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIDrTileIVHH066M-NihYsoM0-CC8zOXftjXYy8nAGaNVRPFrYT109GT_PtWiIGiWSVencrnt3QHamVH6n5gn2-fGx3iw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CJABEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIxRpwiTMfsL-27ybz1sPhTKyrpN9lH0ibB-gFuV2xulzshO735h9ZI_JGw9auHer88dm4Um_RiA3UfmjRlWjv5ctkozw"
+                                        }
+                                      },
+                                      "trackingParams": "CJABEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CI8BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "De1LCQvbqV4"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CI8BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpIDrTileIVHH066M-NihYsoM0-CC8zOXftjXYy8nAGaNVRPFrYT109GT_PtWiIGiWSVencrnt3QHamVH6n5gn2-fGx3iw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CI8BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "De1LCQvbqV4"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CI8BEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CI4BEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "De1LCQvbqV4"
+                                        }
+                                      },
+                                      "trackingParams": "CI4BEMOUBhgFIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CI0BEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_pyQa1mky9hE",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CI0BEI_7BRgGIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIwBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CIwBEJD7BRgHIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIsBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtEZTFMQ1F2YnFWNA%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CIsBEJH7BRgIIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CIoBEKc7IhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "De1LCQvbqV4"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CHoQ4WcYDCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/g8bzAg2zxvdnm7ismLMYLA9-9azb4y6VP2uOF56A2G2rpsqLHT6mrJWXRKq_VttXQZ-o-jmVgTFIVgdj=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/g8bzAg2zxvdnm7ismLMYLA9-9azb4y6VP2uOF56A2G2rpsqLHT6mrJWXRKq_VttXQZ-o-jmVgTFIVgdj=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CIgBEIS_AiITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CIcBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                      "watchEndpoint": {
+                                        "videoId": "PVBNm6l3yrI",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CIcBEMjeAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Something (Take 39 / Instrumental / Strings Only) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Something (Take 39 / Instrumental / Strings Only) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Something (Take 39 / Instrumental / Strings Only)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CHoQ4WcYDCITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "PVBNm6l3yrI",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CHoQ4WcYDCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Abbey Road (Super Deluxe Edition)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CHoQ4WcYDCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_tQfaWH32ovE",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:42"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "1M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CIYBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIumgEDEPQk",
+                                        "watchEndpoint": {
+                                          "videoId": "PVBNm6l3yrI",
+                                          "playlistId": "RDAMVMPVBNm6l3yrI",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1QVkJObTZsM3lySQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CIYBEJvzBRgAIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CIQBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "PVBNm6l3yrI",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CIQBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "PVBNm6l3yrI"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CIQBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CIUBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CIQBEL7uBRgBIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CIIBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "PVBNm6l3yrI",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CIIBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "watchEndpoint": {
+                                                "videoId": "PVBNm6l3yrI"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CIIBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CIMBEMrHAyITCNyOkcG3rIMDFbUNtwAdxQgCLg=="
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CIIBEPvvBRgCIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CIEBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLJNJuwZaCg1H-FpmVkYdXpFNjOIyMMmOXfvA92xQqLgND1tZ8dbX9gRbcODAibXfm_fl4B46pVxBM1Yhi77vzs-PSkVA"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CIEBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLN5ypeLB9OVSEel5CSTIKzOKMMGfQMphPbMncDH5Ml00Yvpy4dQ9paRqiQwX8T3SDykeKv3q_bmKXKEdAU5X6_CRG_CQ"
+                                        }
+                                      },
+                                      "trackingParams": "CIEBEIT_BRgDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CIABEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "PVBNm6l3yrI"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CIABEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpLJNJuwZaCg1H-FpmVkYdXpFNjOIyMMmOXfvA92xQqLgND1tZ8dbX9gRbcODAibXfm_fl4B46pVxBM1Yhi77vzs-PSkVA"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CIABEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "PVBNm6l3yrI"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CIABEIyfBhgEIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CH8Qw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "PVBNm6l3yrI"
+                                        }
+                                      },
+                                      "trackingParams": "CH8Qw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CH4Qj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_tQfaWH32ovE",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CH4Qj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CH0QkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CH0QkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CHwQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtQVkJObTZsM3lySQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CHwQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CHsQpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "PVBNm6l3yrI"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CGsQ4WcYDSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/0uSK3j19kosq8SmrnZZ_mlw3kL6ZWFcLRgt0cqhACJcA6cEfLgCscIllVfF-LjkuV3zhuYG6MSFih6PdMw=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/0uSK3j19kosq8SmrnZZ_mlw3kL6ZWFcLRgt0cqhACJcA6cEfLgCscIllVfF-LjkuV3zhuYG6MSFih6PdMw=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CHkQhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CHgQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "CXlCLDP2Vr0",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CHgQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Don\u2019t Let Me Down (First Rooftop Performance) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Don\u2019t Let Me Down (First Rooftop Performance) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Don\u2019t Let Me Down (First Rooftop Performance)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CGsQ4WcYDSITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "CXlCLDP2Vr0",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CGsQ4WcYDSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Let It Be (Super Deluxe)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CGsQ4WcYDSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_zBKX8qwlKte",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "3:30"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "503M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CHcQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "CXlCLDP2Vr0",
+                                          "playlistId": "RDAMVMCXlCLDP2Vr0",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1DWGxDTERQMlZyMA%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CHcQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CHUQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "CXlCLDP2Vr0",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CHUQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "CXlCLDP2Vr0"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CHUQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CHYQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CHUQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CHMQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "CXlCLDP2Vr0",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CHMQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "CXlCLDP2Vr0"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CHMQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CHQQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CHMQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CHIQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpK8B5NQThlXHdSBQ1L77BLOpXgGn-FcBcLAf8NQmcqIRGKuPBgJne0hh65VZyDAXCWvUohYACGCYuyLOU-IOKA7dmo8HA"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CHIQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpK6HFp7Vmsfdmo2H2nh_PalspGe8IuL1qP5v0OMZOG_BhV1cadQSzLT6Hnq1izP6I91mYDZWnIPrHYVuc_WtCmjhg2eTw"
+                                        }
+                                      },
+                                      "trackingParams": "CHIQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CHEQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "CXlCLDP2Vr0"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CHEQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpK8B5NQThlXHdSBQ1L77BLOpXgGn-FcBcLAf8NQmcqIRGKuPBgJne0hh65VZyDAXCWvUohYACGCYuyLOU-IOKA7dmo8HA"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CHEQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "CXlCLDP2Vr0"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CHEQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CHAQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "CXlCLDP2Vr0"
+                                        }
+                                      },
+                                      "trackingParams": "CHAQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CG8Qj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_zBKX8qwlKte",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CG8Qj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CG4QkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CG4QkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CG0QkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtDWGxDTERQMlZyMA%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CG0QkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CGwQpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "CXlCLDP2Vr0"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CFwQ4WcYDiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/IjEb5kMRk7qimcH3BCJaK85pf79X383z5KNrAxJSNOHVWC41_e66Id233ZGj1AQhH1H5AiKxQMEbHPn0=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/IjEb5kMRk7qimcH3BCJaK85pf79X383z5KNrAxJSNOHVWC41_e66Id233ZGj1AQhH1H5AiKxQMEbHPn0=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CGoQhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CGkQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "8scSwaKbE64",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CGkQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Nowhere Man (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Nowhere Man (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Nowhere Man (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CFwQ4WcYDiITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "8scSwaKbE64",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CFwQ4WcYDiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Rubber Soul",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CFwQ4WcYDiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_NPpc9jtWHdJ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:44"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "28M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CGgQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "8scSwaKbE64",
+                                          "playlistId": "RDAMVM8scSwaKbE64",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk04c2NTd2FLYkU2NA%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CGgQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CGYQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "8scSwaKbE64",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CGYQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "8scSwaKbE64"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CGYQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CGcQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CGYQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CGQQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "8scSwaKbE64",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CGQQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "8scSwaKbE64"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CGQQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CGUQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CGQQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CGMQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJAwuIrLeoANoJ2iCyZLoQTa0MAMoaC1yjj9crcc1ZRYFbKS4wEf02jBhcyggffF4vt44vZ0v5Y1lXAItqNlTfdhudaIQ"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CGMQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKYNlKx_2lixD5Co99FcVugtqUlyAGy9N9NZASR9xww_oTxEtZ3F7t_SZqydPZkeMfndZwxmwlou5MriwnGrzycoPEEJw"
+                                        }
+                                      },
+                                      "trackingParams": "CGMQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CGIQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "8scSwaKbE64"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CGIQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJAwuIrLeoANoJ2iCyZLoQTa0MAMoaC1yjj9crcc1ZRYFbKS4wEf02jBhcyggffF4vt44vZ0v5Y1lXAItqNlTfdhudaIQ"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CGIQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "8scSwaKbE64"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CGIQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CGEQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "8scSwaKbE64"
+                                        }
+                                      },
+                                      "trackingParams": "CGEQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CGAQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_NPpc9jtWHdJ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CGAQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CF8QkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CF8QkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CF4QkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgs4c2NTd2FLYkU2NA%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CF4QkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CF0QpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "8scSwaKbE64"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CE0Q4WcYDyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/8MFj-k2DNUXPKOw8BawKI291ty1Wh8V4M3J6fiq4itWkjw34ncAem60h80eMzsD2XjczahdZEF69CQ8=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/8MFj-k2DNUXPKOw8BawKI291ty1Wh8V4M3J6fiq4itWkjw34ncAem60h80eMzsD2XjczahdZEF69CQ8=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CFsQhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CFoQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "Man4Xw8Xypo",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CFoQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Blackbird (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Blackbird (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Blackbird (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CE0Q4WcYDyITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "Man4Xw8Xypo",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CE0Q4WcYDyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CE0Q4WcYDyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_S5TiUIYvI78",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:19"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "63M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CFkQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "Man4Xw8Xypo",
+                                          "playlistId": "RDAMVMMan4Xw8Xypo",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1NYW40WHc4WHlwbw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CFkQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CFcQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "Man4Xw8Xypo",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CFcQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "Man4Xw8Xypo"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CFcQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CFgQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CFcQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CFUQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "Man4Xw8Xypo",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CFUQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "Man4Xw8Xypo"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CFUQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CFYQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CFUQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CFQQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLd-v5kjfUs19AObsWthtCRIcREvTu5EYLRd6kQYPxz-CwlQVMOar_lrp2C8xKm7-zX6Fe_FQYRab5Sudo902wVNXLP0A"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CFQQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLPuYE1tv9tuyCUJv8LUMaq9vK8LLYNlXMeMhccp7cNktPVuRtBdhJwy8Nk-Lrc8UKccGZeJlcdbigIcvUs6yfBdca9_g"
+                                        }
+                                      },
+                                      "trackingParams": "CFQQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CFMQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "Man4Xw8Xypo"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CFMQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpLd-v5kjfUs19AObsWthtCRIcREvTu5EYLRd6kQYPxz-CwlQVMOar_lrp2C8xKm7-zX6Fe_FQYRab5Sudo902wVNXLP0A"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CFMQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "Man4Xw8Xypo"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CFMQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CFIQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "Man4Xw8Xypo"
+                                        }
+                                      },
+                                      "trackingParams": "CFIQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CFEQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_S5TiUIYvI78",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CFEQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CFAQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CFAQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CE8QkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtNYW40WHc4WHlwbw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CE8QkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CE4QpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "Man4Xw8Xypo"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CD0Q4WcYECITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/ICQacM23_M2uMsvADP1v4RtdCCKeW-i8neEsDIr3g_qErQQxRg-QD0lUAmORXZ2Os5CQQdiQsW6kT41_Ag=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/ICQacM23_M2uMsvADP1v4RtdCCKeW-i8neEsDIr3g_qErQQxRg-QD0lUAmORXZ2Os5CQQdiQsW6kT41_Ag=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CEwQhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CEsQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "P5ZBISo2CaE",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CEsQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Black Beatles - Rae Sremmurd"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Black Beatles - Rae Sremmurd"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Black Beatles (feat. Gucci Mane)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CD0Q4WcYECITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "P5ZBISo2CaE",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Rae Sremmurd",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CD0Q4WcYECITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC8wglGUW3qSjbvqVdX6JUZA",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "SremmLife 2 (Deluxe)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CD0Q4WcYECITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_jMnxYhq2fA7",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "4:52"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "1.1B\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CEoQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "P5ZBISo2CaE",
+                                          "playlistId": "RDAMVMP5ZBISo2CaE",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk1QNVpCSVNvMkNhRQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CEoQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CEgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "P5ZBISo2CaE",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CEgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "P5ZBISo2CaE"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CEgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CEkQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CEgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CEYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "P5ZBISo2CaE",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CEYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "P5ZBISo2CaE"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CEYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CEcQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CEYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CEUQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpL74JB4YlUJb4Np6A7EZhO9uaXAcBc-50paZgpHcCcyLPR4F37a97cDhU2cuS8BJM1bdYyu_rAXfWYtYXk7VgRHZh6_pw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CEUQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpI-b44vjd3KwG_84LC9VyXRtN_FhIP3LXcSm0G2Wj5CNSTodMnBndcPvkzd1x0fQjkd35WHtQISCOMnBSniovlv_35WRw"
+                                        }
+                                      },
+                                      "trackingParams": "CEUQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CEQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "P5ZBISo2CaE"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CEQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpL74JB4YlUJb4Np6A7EZhO9uaXAcBc-50paZgpHcCcyLPR4F37a97cDhU2cuS8BJM1bdYyu_rAXfWYtYXk7VgRHZh6_pw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CEQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "P5ZBISo2CaE"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CEQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CEMQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "P5ZBISo2CaE"
+                                        }
+                                      },
+                                      "trackingParams": "CEMQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CEIQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_jMnxYhq2fA7",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CEIQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CEEQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC8wglGUW3qSjbvqVdX6JUZA",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CEEQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CEAQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgtQNVpCSVNvMkNhRQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CEAQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CD8QpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "badges": [
+                              {
+                                "musicInlineBadgeRenderer": {
+                                  "trackingParams": "CD4Qoe0CGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                  "icon": {
+                                    "iconType": "MUSIC_EXPLICIT_BADGE"
+                                  },
+                                  "accessibilityData": {
+                                    "accessibilityData": {
+                                      "label": "Explicit"
+                                    }
+                                  }
+                                }
+                              }
+                            ],
+                            "playlistItemData": {
+                              "videoId": "P5ZBISo2CaE"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CC4Q4WcYESITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/8MFj-k2DNUXPKOw8BawKI291ty1Wh8V4M3J6fiq4itWkjw34ncAem60h80eMzsD2XjczahdZEF69CQ8=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/8MFj-k2DNUXPKOw8BawKI291ty1Wh8V4M3J6fiq4itWkjw34ncAem60h80eMzsD2XjczahdZEF69CQ8=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CDwQhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CDsQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "vWW2SzoAXMo",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CDsQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Helter Skelter (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Helter Skelter (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Helter Skelter (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CC4Q4WcYESITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "vWW2SzoAXMo",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CC4Q4WcYESITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CC4Q4WcYESITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_S5TiUIYvI78",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "4:30"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "26M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CDoQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "vWW2SzoAXMo",
+                                          "playlistId": "RDAMVMvWW2SzoAXMo",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk12V1cyU3pvQVhNbw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CDoQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CDgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "vWW2SzoAXMo",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CDgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "vWW2SzoAXMo"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CDgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CDkQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CDgQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CDYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "vWW2SzoAXMo",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CDYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "vWW2SzoAXMo"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CDYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CDcQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CDYQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CDUQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJlRk3hVf3UFkASG1YAA7xYdRMw5_VPwAn0x5aVRiZgBmJTzTknLy44b1dOv4CPNIpLfKHZXV-XC23hBN4vtbWXskYnlA"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CDUQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpLLClEeHF7qvpvKySJbViNe1Cwk2T_cnpInHZd2iWVmTOibvdtWtMRiY_H5wcD8RBT2P2oj3-ORl_StjXRCu0oB8iLzTw"
+                                        }
+                                      },
+                                      "trackingParams": "CDUQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CDQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "vWW2SzoAXMo"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CDQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJlRk3hVf3UFkASG1YAA7xYdRMw5_VPwAn0x5aVRiZgBmJTzTknLy44b1dOv4CPNIpLfKHZXV-XC23hBN4vtbWXskYnlA"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CDQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "vWW2SzoAXMo"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CDQQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CDMQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "vWW2SzoAXMo"
+                                        }
+                                      },
+                                      "trackingParams": "CDMQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CDIQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_S5TiUIYvI78",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CDIQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CDEQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CDEQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CDAQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgt2V1cyU3pvQVhNbw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CDAQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CC8QpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "vWW2SzoAXMo"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CB8Q4WcYEiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/3NgQRedyr9sdsiEUyaJ9k2hTl5eTotzV5-6ABSiSGY9SFuHNJnWFcG9wiI-6sKQwCgXNlwp89VqZKR4C=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/3NgQRedyr9sdsiEUyaJ9k2hTl5eTotzV5-6ABSiSGY9SFuHNJnWFcG9wiI-6sKQwCgXNlwp89VqZKR4C=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CC0QhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CCwQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "3O4J4DH4tyo",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CCwQyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Jealous Guy - John Lennon"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Jealous Guy - John Lennon"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Jealous Guy",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CB8Q4WcYEiITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "3O4J4DH4tyo",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "John Lennon",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CB8Q4WcYEiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UCcSL2nYSJp_IgdzH0xBBdcg",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Imagine",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CB8Q4WcYEiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_gDaohH1B2Wz",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "4:18"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "72M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CCsQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "3O4J4DH4tyo",
+                                          "playlistId": "RDAMVM3O4J4DH4tyo",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk0zTzRKNERINHR5bw%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CCsQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CCkQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "3O4J4DH4tyo",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CCkQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "3O4J4DH4tyo"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CCkQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CCoQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CCkQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CCcQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "3O4J4DH4tyo",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CCcQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "3O4J4DH4tyo"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CCcQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CCgQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CCcQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CCYQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpJ1y1OO0mNwW84fwP32KniWqZteGc9kFD5hT-gEti3bGYU-b-q58Q8oJX8hgmhSYILZoGzMraqxl6GGJQN6_SFpKJ63Mw"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CCYQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpIojX2LOBTounLrn421BGs2NqdJXpoLcnBw5T09AMibATCp_62a7Kuen7AJ6RQ-65AkLkO0nVNrqFgydnz4iCq_ba1llQ"
+                                        }
+                                      },
+                                      "trackingParams": "CCYQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CCUQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "3O4J4DH4tyo"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CCUQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpJ1y1OO0mNwW84fwP32KniWqZteGc9kFD5hT-gEti3bGYU-b-q58Q8oJX8hgmhSYILZoGzMraqxl6GGJQN6_SFpKJ63Mw"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CCUQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "3O4J4DH4tyo"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CCUQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CCQQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "3O4J4DH4tyo"
+                                        }
+                                      },
+                                      "trackingParams": "CCQQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CCMQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_gDaohH1B2Wz",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CCMQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CCIQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UCcSL2nYSJp_IgdzH0xBBdcg",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CCIQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CCEQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "CgszTzRKNERINHR5bw%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CCEQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CCAQpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "3O4J4DH4tyo"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "trackingParams": "CBAQ4WcYEyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "thumbnail": {
+                              "musicThumbnailRenderer": {
+                                "thumbnail": {
+                                  "thumbnails": [
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/BfHLoMyzk389QwfEx3Ewr-J4g0nCbbrVzBt43qHtdfnX75veUIropjgAShejer3PzEG3yjSEZsLr-Q9a=w60-h60-l90-rj",
+                                      "width": 60,
+                                      "height": 60
+                                    },
+                                    {
+                                      "url": "https://lh3.googleusercontent.com/BfHLoMyzk389QwfEx3Ewr-J4g0nCbbrVzBt43qHtdfnX75veUIropjgAShejer3PzEG3yjSEZsLr-Q9a=w120-h120-l90-rj",
+                                      "width": 120,
+                                      "height": 120
+                                    }
+                                  ]
+                                },
+                                "thumbnailCrop": "MUSIC_THUMBNAIL_CROP_UNSPECIFIED",
+                                "thumbnailScale": "MUSIC_THUMBNAIL_SCALE_ASPECT_FIT",
+                                "trackingParams": "CB4QhL8CIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                              }
+                            },
+                            "overlay": {
+                              "musicItemThumbnailOverlayRenderer": {
+                                "background": {
+                                  "verticalGradient": {
+                                    "gradientLayerColors": [
+                                      "3422552064",
+                                      "3422552064"
+                                    ]
+                                  }
+                                },
+                                "content": {
+                                  "musicPlayButtonRenderer": {
+                                    "playNavigationEndpoint": {
+                                      "clickTrackingParams": "CB0QyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                      "watchEndpoint": {
+                                        "videoId": "ysDwR5SIR1Q",
+                                        "watchEndpointMusicSupportedConfigs": {
+                                          "watchEndpointMusicConfig": {
+                                            "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "trackingParams": "CB0QyN4CIhMI3I6RwbesgwMVtQ23AB3FCAIu",
+                                    "playIcon": {
+                                      "iconType": "PLAY_ARROW"
+                                    },
+                                    "pauseIcon": {
+                                      "iconType": "PAUSE"
+                                    },
+                                    "iconColor": 4294967295,
+                                    "backgroundColor": 0,
+                                    "activeBackgroundColor": 0,
+                                    "loadingIndicatorColor": 4294901760,
+                                    "playingIcon": {
+                                      "iconType": "VOLUME_UP"
+                                    },
+                                    "iconLoadingColor": 0,
+                                    "activeScaleFactor": 1,
+                                    "buttonSize": "MUSIC_PLAY_BUTTON_SIZE_SMALL",
+                                    "rippleTarget": "MUSIC_PLAY_BUTTON_RIPPLE_TARGET_SELF",
+                                    "accessibilityPlayData": {
+                                      "accessibilityData": {
+                                        "label": "Play Lovely Rita (Remastered 2009) - The Beatles"
+                                      }
+                                    },
+                                    "accessibilityPauseData": {
+                                      "accessibilityData": {
+                                        "label": "Pause Lovely Rita (Remastered 2009) - The Beatles"
+                                      }
+                                    }
+                                  }
+                                },
+                                "contentPosition": "MUSIC_ITEM_THUMBNAIL_OVERLAY_CONTENT_POSITION_CENTERED",
+                                "displayStyle": "MUSIC_ITEM_THUMBNAIL_OVERLAY_DISPLAY_STYLE_PERSISTENT"
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Lovely Rita (Remastered 2009)",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CBAQ4WcYEyITCNyOkcG3rIMDFbUNtwAdxQgCLpoBAxD0JA==",
+                                          "watchEndpoint": {
+                                            "videoId": "ysDwR5SIR1Q",
+                                            "watchEndpointMusicSupportedConfigs": {
+                                              "watchEndpointMusicConfig": {
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "The Beatles",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CBAQ4WcYEyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "Sgt. Pepper's Lonely Hearts Club Band",
+                                        "navigationEndpoint": {
+                                          "clickTrackingParams": "CBAQ4WcYEyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                                          "browseEndpoint": {
+                                            "browseId": "MPREb_MlGHASFrLIn",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " \u2022 "
+                                      },
+                                      {
+                                        "text": "2:43"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "9.4M\u00a0plays"
+                                      }
+                                    ]
+                                  },
+                                  "displayPriority": "MUSIC_RESPONSIVE_LIST_ITEM_COLUMN_DISPLAY_PRIORITY_HIGH"
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Start radio"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "MIX"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CBwQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi6aAQMQ9CQ=",
+                                        "watchEndpoint": {
+                                          "videoId": "ysDwR5SIR1Q",
+                                          "playlistId": "RDAMVMysDwR5SIR1Q",
+                                          "params": "wAEB",
+                                          "loggingContext": {
+                                            "vssLoggingContext": {
+                                              "serializedContextData": "GhFSREFNVk15c0R3UjVTSVIxUQ%3D%3D"
+                                            }
+                                          },
+                                          "watchEndpointMusicSupportedConfigs": {
+                                            "watchEndpointMusicConfig": {
+                                              "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CBwQm_MFGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Play next"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "QUEUE_PLAY_NEXT"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CBoQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "ysDwR5SIR1Q",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CBoQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "ysDwR5SIR1Q"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AFTER_CURRENT_VIDEO",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CBoQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song will play next"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CBsQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CBoQvu4FGAEiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuServiceItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to queue"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_REMOTE_QUEUE"
+                                      },
+                                      "serviceEndpoint": {
+                                        "clickTrackingParams": "CBgQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "queueAddEndpoint": {
+                                          "queueTarget": {
+                                            "videoId": "ysDwR5SIR1Q",
+                                            "onEmptyQueue": {
+                                              "clickTrackingParams": "CBgQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "watchEndpoint": {
+                                                "videoId": "ysDwR5SIR1Q"
+                                              }
+                                            }
+                                          },
+                                          "queueInsertPosition": "INSERT_AT_END",
+                                          "commands": [
+                                            {
+                                              "clickTrackingParams": "CBgQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "addToToastAction": {
+                                                "item": {
+                                                  "notificationTextRenderer": {
+                                                    "successResponseText": {
+                                                      "runs": [
+                                                        {
+                                                          "text": "Song added to queue"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "trackingParams": "CBkQyscDIhMI3I6RwbesgwMVtQ23AB3FCAIu"
+                                                  }
+                                                }
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "trackingParams": "CBgQ--8FGAIiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to library"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "LIBRARY_ADD"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CBcQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpITB9stQVEAk-2R_A9nxX1Wapl6qQhCXFfcCO7DSoMleMe1mru_yeLC69Z3aAon-gunwOarpy_GdGzL9oMDMltBmF9Kag"
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from library"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "LIBRARY_SAVED"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CBcQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "feedbackEndpoint": {
+                                          "feedbackToken": "AB9zfpKflxLtZltIdmNLxYEmdZpfH1WOU0oVMAL98-H-DI9BrnvPfkFH1KTCtqObPF2P8GP34Gjhpxb-NFCMob2pfp0INh7S5A"
+                                        }
+                                      },
+                                      "trackingParams": "CBcQhP8FGAMiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "toggleMenuServiceItemRenderer": {
+                                      "defaultText": {
+                                        "runs": [
+                                          {
+                                            "text": "Add to liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "defaultIcon": {
+                                        "iconType": "FAVORITE"
+                                      },
+                                      "defaultServiceEndpoint": {
+                                        "clickTrackingParams": "CBYQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "LIKE",
+                                          "target": {
+                                            "videoId": "ysDwR5SIR1Q"
+                                          },
+                                          "actions": [
+                                            {
+                                              "clickTrackingParams": "CBYQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                              "musicLibraryStatusUpdateCommand": {
+                                                "libraryStatus": "MUSIC_LIBRARY_STATUS_IN_LIBRARY",
+                                                "addToLibraryFeedbackToken": "AB9zfpITB9stQVEAk-2R_A9nxX1Wapl6qQhCXFfcCO7DSoMleMe1mru_yeLC69Z3aAon-gunwOarpy_GdGzL9oMDMltBmF9Kag"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      },
+                                      "toggledText": {
+                                        "runs": [
+                                          {
+                                            "text": "Remove from liked songs"
+                                          }
+                                        ]
+                                      },
+                                      "toggledIcon": {
+                                        "iconType": "UNFAVORITE"
+                                      },
+                                      "toggledServiceEndpoint": {
+                                        "clickTrackingParams": "CBYQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "likeEndpoint": {
+                                          "status": "INDIFFERENT",
+                                          "target": {
+                                            "videoId": "ysDwR5SIR1Q"
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CBYQjJ8GGAQiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Save to playlist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ADD_TO_PLAYLIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CBUQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "addToPlaylistEndpoint": {
+                                          "videoId": "ysDwR5SIR1Q"
+                                        }
+                                      },
+                                      "trackingParams": "CBUQw5QGGAUiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to album"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ALBUM"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CBQQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "MPREb_MlGHASFrLIn",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CBQQj_sFGAYiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Go to artist"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "ARTIST"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CBMQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "browseEndpoint": {
+                                          "browseId": "UC2XdaAVUannpujzv32jcouQ",
+                                          "browseEndpointContextSupportedConfigs": {
+                                            "browseEndpointContextMusicConfig": {
+                                              "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "trackingParams": "CBMQkPsFGAciEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  },
+                                  {
+                                    "menuNavigationItemRenderer": {
+                                      "text": {
+                                        "runs": [
+                                          {
+                                            "text": "Share"
+                                          }
+                                        ]
+                                      },
+                                      "icon": {
+                                        "iconType": "SHARE"
+                                      },
+                                      "navigationEndpoint": {
+                                        "clickTrackingParams": "CBIQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                        "shareEntityEndpoint": {
+                                          "serializedShareEntity": "Cgt5c0R3UjVTSVIxUQ%3D%3D",
+                                          "sharePanelType": "SHARE_PANEL_TYPE_UNIFIED_SHARE_PANEL"
+                                        }
+                                      },
+                                      "trackingParams": "CBIQkfsFGAgiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+                                    }
+                                  }
+                                ],
+                                "trackingParams": "CBEQpzsiEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                                "accessibility": {
+                                  "accessibilityData": {
+                                    "label": "Action menu"
+                                  }
+                                }
+                              }
+                            },
+                            "playlistItemData": {
+                              "videoId": "ysDwR5SIR1Q"
+                            },
+                            "flexColumnDisplayStyle": "MUSIC_RESPONSIVE_LIST_ITEM_FLEX_COLUMN_DISPLAY_STYLE_TWO_LINE_STACK",
+                            "itemHeight": "MUSIC_RESPONSIVE_LIST_ITEM_HEIGHT_TALL"
+                          }
+                        }
+                      ],
+                      "trackingParams": "FAKE_TRACKING_PARAMS"
+                    }
+                  }
+                ],
+                "trackingParams": "CAIQui8iEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                "header": {
+                  "chipCloudRenderer": {
+                    "chips": [
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_SECONDARY"
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CA0Q_V0YACITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles"
+                            }
+                          },
+                          "trackingParams": "CA0Q_V0YACITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "icon": {
+                            "iconType": "CLOSE"
+                          },
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Clear filters"
+                            }
+                          },
+                          "isSelected": false
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Albums"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAwQ_V0YASITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQIYAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAwQ_V0YASITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show album results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Albums"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Featured playlists"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAsQ_V0YAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgeKAQQoADgBahIQCRAOEAoQAxAFEAQQERAQEBU%3D"
+                            }
+                          },
+                          "trackingParams": "CAsQ_V0YAiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show featured playlist results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Featured playlists"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Community playlists"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAoQ_V0YAyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgeKAQQoAEABahIQCRAOEAoQAxAFEAQQERAQEBU%3D"
+                            }
+                          },
+                          "trackingParams": "CAoQ_V0YAyITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show community playlist results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Community playlists"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_PRIMARY"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Songs"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAkQ_V0YBCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQIIAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAkQ_V0YBCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show song results selected"
+                            }
+                          },
+                          "isSelected": true,
+                          "uniqueId": "Songs"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Artists"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAgQ_V0YBSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQIgAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAgQ_V0YBSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show artist results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Artists"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Videos"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAcQ_V0YBiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQIQAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAcQ_V0YBiITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show video results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Videos"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Podcasts"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAYQ_V0YByITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQJQAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAYQ_V0YByITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show podcast results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Podcasts"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Episodes"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAUQ_V0YCCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQJIAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAUQ_V0YCCITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show podcast episode results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Episodes"
+                        }
+                      },
+                      {
+                        "chipCloudChipRenderer": {
+                          "style": {
+                            "styleType": "STYLE_DEFAULT"
+                          },
+                          "text": {
+                            "runs": [
+                              {
+                                "text": "Profiles"
+                              }
+                            ]
+                          },
+                          "navigationEndpoint": {
+                            "clickTrackingParams": "CAQQ_V0YCSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                            "searchEndpoint": {
+                              "query": "beatles",
+                              "params": "EgWKAQJYAWoSEAkQDhAKEAMQBRAEEBEQEBAV"
+                            }
+                          },
+                          "trackingParams": "CAQQ_V0YCSITCNyOkcG3rIMDFbUNtwAdxQgCLg==",
+                          "accessibilityData": {
+                            "accessibilityData": {
+                              "label": "Show profile results"
+                            }
+                          },
+                          "isSelected": false,
+                          "uniqueId": "Profiles"
+                        }
+                      }
+                    ],
+                    "collapsedRowCount": 1,
+                    "trackingParams": "CAMQ_F0iEwjcjpHBt6yDAxW1DbcAHcUIAi4=",
+                    "horizontalScrollable": true
+                  }
+                }
+              }
+            },
+            "tabIdentifier": "music_search_catalog",
+            "trackingParams": "CAEQ8JMBGAAiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+          }
+        }
+      ]
+    }
+  },
+  "trackingParams": "CAAQvGkiEwjcjpHBt6yDAxW1DbcAHcUIAi4="
+}

--- a/ytmapi-rs/tests/live_integration_tests.rs
+++ b/ytmapi-rs/tests/live_integration_tests.rs
@@ -128,43 +128,43 @@ generate_stream_test_logged_in!(
 );
 generate_stream_test!(
     test_stream_search_artists,
-    SearchQuery::new("Beatles").with_filter(ArtistsFilter)
+    SearchQuery::new_filtered("Beatles", ArtistsFilter)
 );
 generate_stream_test!(
     test_stream_search_songs,
-    SearchQuery::new("Beatles").with_filter(SongsFilter)
+    SearchQuery::new_filtered("Beatles", SongsFilter)
 );
 generate_stream_test!(
     test_stream_search_albums,
-    SearchQuery::new("Beatles").with_filter(AlbumsFilter)
+    SearchQuery::new_filtered("Beatles", AlbumsFilter)
 );
 generate_stream_test!(
     test_stream_search_videos,
-    SearchQuery::new("Beatles").with_filter(VideosFilter)
+    SearchQuery::new_filtered("Beatles", VideosFilter)
 );
 generate_stream_test!(
     test_stream_search_episodes,
-    SearchQuery::new("Beatles").with_filter(EpisodesFilter)
+    SearchQuery::new_filtered("Beatles", EpisodesFilter)
 );
 generate_stream_test!(
     test_stream_search_podcasts,
-    SearchQuery::new("Beatles").with_filter(PodcastsFilter)
+    SearchQuery::new_filtered("Beatles", PodcastsFilter)
 );
 generate_stream_test!(
     test_stream_search_profiles,
-    SearchQuery::new("Beatles").with_filter(ProfilesFilter)
+    SearchQuery::new_filtered("Beatles", ProfilesFilter)
 );
 generate_stream_test!(
     test_stream_search_featured_playlists,
-    SearchQuery::new("Beatles").with_filter(FeaturedPlaylistsFilter)
+    SearchQuery::new_filtered("Beatles", FeaturedPlaylistsFilter)
 );
 generate_stream_test!(
     test_stream_search_community_playlists,
-    SearchQuery::new("Beatles").with_filter(CommunityPlaylistsFilter)
+    SearchQuery::new_filtered("Beatles", CommunityPlaylistsFilter)
 );
 generate_stream_test!(
     test_stream_search_playlists,
-    SearchQuery::new("Beatles").with_filter(PlaylistsFilter)
+    SearchQuery::new_filtered("Beatles", PlaylistsFilter)
 );
 generate_stream_test!(
     test_stream_get_playlist,


### PR DESCRIPTION
This is an updated version of #375 with the LLM-generated comments removed.
Additionally, code has been refactored to;
- avoid the anti-pattern of manually creating `JsonCrawler`s
- rename methods to reflect that `FilteredSearchMusicShelfContents` is not the correct name, in the new schema.
- remove the hard-to-grok tryfrom/tryinto implementations in favour of just calling functions or using iterator methods.
- tidy deprecation warnings from previous release